### PR TITLE
Charge requires either a card or a customer

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -102,7 +102,7 @@ module StripeMock
     def get_customer_card(customer, token)
       customer[:cards][:data].find{|cc| cc[:id] == token }
     end
-    
+
     def add_card_to_customer(card, cus)
       card[:customer] = cus[:id]
 

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -12,7 +12,7 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
         charges[id] = Data.mock_charge(params.merge :id => id)
-        assert_existance :charge, $1, (charges[id][:card] || charges[id][:customer])
+        assert_existance :charge, id, (charges[id][:card] || charges[id][:customer])
         charges[id]
       end
 

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -12,6 +12,8 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
         charges[id] = Data.mock_charge(params.merge :id => id)
+        assert_existance :charge, $1, (charges[id][:card] || charges[id][:customer])
+        charges[id]
       end
 
       def get_charge(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -16,6 +16,35 @@ shared_examples 'Charge API' do
     expect(charge.captured).to eq(true)
   end
 
+  it "creates a stripe charge item with a customer token" do
+    charge = Stripe::Charge.create(
+      amount: 999,
+      currency: 'USD',
+      customer: 'card_token_abcde',
+      description: 'card charge'
+    )
+
+    expect(charge.id).to match(/^test_ch/)
+    expect(charge.amount).to eq(999)
+    expect(charge.description).to eq('card charge')
+    expect(charge.captured).to eq(true)
+  end
+
+  it "cannot create a stripe charge item without either a card token or a customer token" do
+    expect {
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: nil,
+        description: 'card charge'
+      )
+    }.to raise_error {|e|
+      expect(e).to be_a Stripe::InvalidRequestError
+      expect(e.param).to eq('charge')
+      expect(e.http_status).to eq(404)
+    }
+  end
+
 
   it "stores a created stripe charge in memory" do
     charge = Stripe::Charge.create({

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -32,7 +32,7 @@ shared_examples 'Charge API' do
 
   it "cannot create a stripe charge item without either a card token or a customer token" do
     expect {
-      charge = Stripe::Charge.create(
+      Stripe::Charge.create(
         amount: 999,
         currency: 'USD',
         card: nil,


### PR DESCRIPTION
Stripe requires that either a card or a customer be specified when creating a charge, otherwise it throws an InvalidRequest error.  I needed this in order to test that case in my own app, so thought it'd be nice if it was included in the gem as well.  Let me know if there is anything you think I should change.  Thanks!
