### PR TITLE
Create customer with coupon discount

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -34,6 +34,7 @@ require 'stripe_mock/api/webhooks'
 require 'stripe_mock/request_handlers/helpers/card_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/subscription_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
+require 'stripe_mock/request_handlers/helpers/coupon_helpers.rb'
 
 require 'stripe_mock/request_handlers/charges.rb'
 require 'stripe_mock/request_handlers/cards.rb'

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -21,6 +21,13 @@ module StripeMock
         params[:subscriptions] = Data.mock_subscriptions_array(url: "/v1/customers/#{params[:id]}/subscriptions")
         customers[ params[:id] ] = Data.mock_customer(cards, params)
 
+        if params[:coupon]
+          coupon = coupons[ params[:coupon] ]
+          assert_existance :coupon, params[:coupon], coupon
+
+          add_coupon_to_customer(customers[params[:id]], coupon)
+        end
+
         if params[:plan]
           plan = plans[ params[:plan] ]
           assert_existance :plan, params[:plan], plan

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -55,6 +55,13 @@ module StripeMock
           cus[:default_card] = new_card[:id]
         end
 
+        if params[:coupon]
+          coupon = coupons[ params[:coupon] ]
+          assert_existance :coupon, params[:coupon], coupon
+
+          add_coupon_to_customer(cus, coupon)
+        end
+
         cus
       end
 

--- a/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
@@ -1,0 +1,13 @@
+module StripeMock
+  module RequestHandlers
+    module Helpers
+
+      def add_coupon_to_customer(customer, coupon)
+        customer[:discount] = { coupon: coupon }
+
+        customer
+      end
+
+    end
+  end
+end

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "1.10.1.4"
+  VERSION = "1.10.1.4.1"
 end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -66,6 +66,26 @@ shared_examples 'Customer API' do
     }
   end
 
+  it 'creates a customer with a coupon discount' do
+    coupon = Stripe::Coupon.create(id: "10PERCENT")
+
+    customer =
+      Stripe::Customer.create(id: 'test_cus_coupon', coupon: '10PERCENT')
+
+    customer = Stripe::Customer.retrieve('test_cus_coupon')
+    expect(customer.discount).to_not be_nil
+    expect(customer.discount.coupon).to_not be_nil
+  end
+
+  it 'cannot create a customer with a coupon that does not exist' do
+    expect{
+      customer = Stripe::Customer.create(id: 'test_cus_no_coupon', coupon: '5OFF')
+    }.to raise_error {|e|
+      expect(e).to be_a(Stripe::InvalidRequestError)
+      expect(e.message).to eq('No such coupon: 5OFF')
+    }
+  end
+
   it "stores a created stripe customer in memory" do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -138,15 +138,19 @@ shared_examples 'Customer API' do
     original = Stripe::Customer.create(id: 'test_customer_update')
     email = original.email
 
+    coupon = Stripe::Coupon.create(id: "10PERCENT")
     original.description = 'new desc'
+    original.coupon      = coupon.id
     original.save
 
     expect(original.email).to eq(email)
     expect(original.description).to eq('new desc')
+    expect(original.discount.coupon).to be_a Stripe::Coupon
 
     customer = Stripe::Customer.retrieve("test_customer_update")
     expect(customer.email).to eq(original.email)
     expect(customer.description).to eq('new desc')
+    expect(customer.discount.coupon).to be_a Stripe::Coupon
   end
 
   it "updates a stripe customer's card" do


### PR DESCRIPTION
Referencing https://github.com/rebelidealist/stripe-ruby-mock/issues/72

Customers can be created now passing a coupon id. Created customers will have the discount field set to the coupon as long as the coupon passed existed in the first place.

Any comments let me know.