### PR TITLE
Make subscription cancelation behavior match Stripe

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -30,6 +30,13 @@ module StripeMock
         cus[:subscriptions][:data] << sub
       end
 
+      def delete_subscription_from_customer(cus, subscription)
+        cus[:subscriptions][:data].reject!{|sub|
+          sub[:id] == subscription[:id]
+        }
+        cus[:subscriptions][:count] -=1
+      end
+
       # `intervals` is set to 1 when calculating current_period_end from current_period_start & plan
       # `intervals` is set to 2 when calculating Stripe::Invoice.upcoming end from current_period_start & plan
       def get_ending_time(start_time, plan, intervals = 1)

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,8 @@ module StripeMock
         assert_existance :subscription, $2, subscription
 
         cancel_params = { canceled_at: Time.now.utc.to_i }
-        if params[:at_period_end] == true
+        cancelled_at_period_end = (params[:at_period_end] == true)
+        if cancelled_at_period_end
           cancel_params[:cancel_at_period_end] = true
         else
           cancel_params[:status] = "canceled"
@@ -112,11 +113,10 @@ module StripeMock
 
         subscription.merge!(cancel_params)
 
-        customer[:subscriptions][:data].reject!{|sub|
-          sub[:id] == subscription[:id]
-        }
+        unless cancelled_at_period_end
+          delete_subscription_from_customer customer, subscription
+        end
 
-        customer[:subscriptions][:data] << subscription
         subscription
       end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -426,17 +426,13 @@ shared_examples 'Customer Subscriptions' do
 
       expect(result.status).to eq('canceled')
       expect(result.cancel_at_period_end).to be_false
+      expect(result.canceled_at).to_not be_nil
       expect(result.id).to eq(sub.id)
 
       customer = Stripe::Customer.retrieve('test_customer_sub')
-      expect(customer.subscriptions.data).to_not be_empty
-      expect(customer.subscriptions.count).to eq(1)
-      expect(customer.subscriptions.data.length).to eq(1)
-
-      expect(customer.subscriptions.data.first.status).to eq('canceled')
-      expect(customer.subscriptions.data.first.cancel_at_period_end).to be_false
-      expect(customer.subscriptions.data.first.ended_at).to_not be_nil
-      expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+      expect(customer.subscriptions.data.length).to eq(0)
     end
 
     it "cancels a stripe customer's subscription at period end" do


### PR DESCRIPTION
If you delete a subscription in stripe without setting at_end_period to true, it immediately deletes the subscription. If you fetch the customer and look at it's subscriptions, it is gone. However, with stripe-ruby-mock, the subscription stays around in the cancelled state. This fix corrects that issue.
