### PR TITLE
Add refunds

### DIFF
--- a/bin/stripe-mock-server
+++ b/bin/stripe-mock-server
@@ -4,6 +4,8 @@ lib = File.expand_path(File.dirname(__FILE__) + '/../lib')
 $LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
 
 require 'trollop'
+require 'stripe_mock'
+require 'stripe_mock/server'
 
 opts = Trollop::options do
   opt :port, "Listening port", :type => :int, :default => 4999
@@ -11,9 +13,7 @@ opts = Trollop::options do
   opt :server, "Server to use", :type => :string, :default => 'thin'
   opt :debug, "Request and response output", :default => true
   opt :pid_path, "Location to put server pid file", :type => :string, :default => './stripe-mock-server.pid'
+  opt :"api-version", "API version (as a date, ex: 2014-06-17)", :type => :string, :default => StripeMock::FIRST_VERSION_DATE
 end
-
-require 'stripe_mock'
-require 'stripe_mock/server'
 
 StripeMock::Server.start_new(opts)

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -54,8 +54,10 @@ module StripeMock
   lib_dir = File.expand_path(File.dirname(__FILE__), '../..')
   @webhook_fixture_path = './spec/fixtures/stripe_webhooks/'
   @webhook_fixture_fallback_path = File.join(lib_dir, 'stripe_mock/webhook_fixtures')
+  @version = nil
 
   class << self
     attr_accessor :webhook_fixture_path
+    attr_accessor :version
   end
 end

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -36,6 +36,7 @@ require 'stripe_mock/request_handlers/helpers/subscription_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
 
 require 'stripe_mock/request_handlers/charges.rb'
+require 'stripe_mock/request_handlers/refunds.rb'
 require 'stripe_mock/request_handlers/cards.rb'
 require 'stripe_mock/request_handlers/customers.rb'
 require 'stripe_mock/request_handlers/coupons.rb'

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -51,10 +51,12 @@ require 'stripe_mock/instance'
 
 module StripeMock
 
+  FIRST_VERSION_DATE = "2011-06-21"
+
   lib_dir = File.expand_path(File.dirname(__FILE__), '../..')
   @webhook_fixture_path = './spec/fixtures/stripe_webhooks/'
   @webhook_fixture_fallback_path = File.join(lib_dir, 'stripe_mock/webhook_fixtures')
-  @version = nil
+  @version = FIRST_VERSION_DATE
 
   class << self
     attr_accessor :webhook_fixture_path

--- a/lib/stripe_mock/api/server.rb
+++ b/lib/stripe_mock/api/server.rb
@@ -8,7 +8,6 @@ module StripeMock
     @default_pid_path = new_path
   end
 
-
   def self.spawn_server(opts={})
     pid_path = opts[:pid_path] || @default_pid_path
     log_path = opts[:log_path] || @default_log_path

--- a/lib/stripe_mock/client.rb
+++ b/lib/stripe_mock/client.rb
@@ -23,6 +23,10 @@ module StripeMock
       end
     end
 
+    def set_version(version)
+      timeout_wrap { @pipe.set_version(version) }
+    end
+
     def get_server_data(key)
       timeout_wrap {
         # Massage the data make this behave the same as the local StripeMock.start

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -31,9 +31,8 @@ module StripeMock
     end
 
     def self.mock_charge(params={})
-      charge_id = params[:id] || "ch_1fD6uiR9FAA2zc"
       {
-        id: charge_id,
+        id: "ch_1fD6uiR9FAA2zc",
         object: "charge",
         created: 1366194027,
         livemode: false,
@@ -64,12 +63,7 @@ module StripeMock
           address_zip_check: nil
         },
         captured: params.has_key?(:capture) ? params.delete(:capture) : true,
-        refunds: {
-          object: "list",
-          count: "0",
-          url: "/v1/charges/#{charge_id}/refunds",
-          data: []
-        },
+        refunds: [],
         balance_transaction: "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
@@ -83,7 +77,35 @@ module StripeMock
       }.merge(params)
     end
 
+    def self.mock_charge_2014_06_17(params={})
+      charge = mock_charge(params)
+      charge_id = charge[:id]
+      charge[:refunds] = {
+        object: "list",
+        count: "0",
+        url: "/v1/charges/#{charge_id}/refunds",
+        data: []
+      }
+      charge
+    end
+
     def self.mock_refund(params={})
+      mock_charge(params[:charge]).merge({
+        refunded: true,
+        refunds: [
+          {
+            amount: params[:refund][:amount],
+            currency: "usd",
+            created: 1380208998,
+            object: "refund",
+            balance_transaction: params[:refund][:balance_transaction]
+          }
+        ],
+        amount_refunded: params[:refund][:amount]
+      })
+    end
+
+    def self.mock_refund_2014_06_17(params={})
       {
         charge: "test_ch_1fD6uiR9FAA2zc",
         amount: 1,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -31,8 +31,9 @@ module StripeMock
     end
 
     def self.mock_charge(params={})
+      charge_id = params[:id] || "ch_1fD6uiR9FAA2zc"
       {
-        id: "ch_1fD6uiR9FAA2zc",
+        id: charge_id,
         object: "charge",
         created: 1366194027,
         livemode: false,
@@ -63,8 +64,12 @@ module StripeMock
           address_zip_check: nil
         },
         captured: params.has_key?(:capture) ? params.delete(:capture) : true,
-        refunds: [
-        ],
+        refunds: {
+          object: "list",
+          count: "0",
+          url: "/v1/charges/#{charge_id}/refunds",
+          data: []
+        },
         balance_transaction: "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
@@ -79,19 +84,16 @@ module StripeMock
     end
 
     def self.mock_refund(params={})
-      mock_charge(params[:charge]).merge({
-        refunded: true,
-        refunds: [
-          {
-            amount: params[:refund][:amount],
-            currency: "usd",
-            created: 1380208998,
-            object: "refund",
-            balance_transaction: params[:refund][:balance_transaction]
-          }
-        ],
-        amount_refunded: params[:refund][:amount]
-      })
+      {
+        charge: "test_ch_1fD6uiR9FAA2zc",
+        amount: 1,
+        currency: "usd",
+        created: 1380208998,
+        object: "refund",
+        balance_transaction: "txn_2dyYXXP90MN26R",
+        id: 'test_re_default'
+      }.merge(params)
+
     end
 
     def self.mock_charge_array

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -18,6 +18,7 @@ module StripeMock
     end
 
     include StripeMock::RequestHandlers::Charges
+    include StripeMock::RequestHandlers::Refunds
     include StripeMock::RequestHandlers::Cards
     include StripeMock::RequestHandlers::Subscriptions # must be before Customers
     include StripeMock::RequestHandlers::Customers

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -15,7 +15,15 @@ module StripeMock
     end
 
     def self.handler_for_method_url(method_url)
-      @@handlers.find {|h| method_url =~ h[:route] && h[:version] == StripeMock.version }
+      api_version_date = Date.strptime(StripeMock.version, '%Y-%m-%d')
+      default_handler = @@handlers.find {|h| method_url =~ h[:route] }
+
+      # Try to find a handler closest to the current version of the API
+      handlers = @@handlers.select {|h|
+        method_url =~ h[:route] && !h[:version].nil? && Date.strptime(h[:version], '%Y-%m-%d') <= api_version_date
+      }.sort_by {|h| h[:version]}
+
+      handlers.first || default_handler
     end
 
     include StripeMock::RequestHandlers::Charges

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -6,15 +6,16 @@ module StripeMock
     # Handlers are ordered by priority
     @@handlers = []
 
-    def self.add_handler(route, name)
+    def self.add_handler(route, name, version=nil)
       @@handlers << {
         :route => %r{^#{route}$},
-        :name => name
+        :name => name,
+        :version => version
       }
     end
 
     def self.handler_for_method_url(method_url)
-      @@handlers.find {|h| method_url =~ h[:route] }
+      @@handlers.find {|h| method_url =~ h[:route] && h[:version] == StripeMock.version }
     end
 
     include StripeMock::RequestHandlers::Charges

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -4,6 +4,7 @@ module StripeMock
 
       def Charges.included(klass)
         klass.add_handler 'post /v1/charges',               :new_charge
+        klass.add_handler 'post /v1/charges',               :new_charge_2014_06_17, '2014-06-17'
         klass.add_handler 'get /v1/charges',                :get_charges
         klass.add_handler 'get /v1/charges/(.*)',           :get_charge
         klass.add_handler 'post /v1/charges/(.*)/capture',  :capture_charge
@@ -18,6 +19,16 @@ module StripeMock
         end
 
         charges[id] = Data.mock_charge(params.merge :id => id, :balance_transaction => new_balance_transaction('txn'))
+      end
+
+      def new_charge_2014_06_17(route, method_url, params, headers)
+        id = new_id('ch')
+
+        if params[:card] && params[:card].is_a?(String)
+          params[:card] = get_card_by_token(params[:card])
+        end
+
+        charges[id] = Data.mock_charge_2014_06_17(params.merge :id => id, :balance_transaction => new_balance_transaction('txn'))
       end
 
       def get_charges(route, method_url, params, headers)
@@ -51,7 +62,8 @@ module StripeMock
       def refund_charge(route, method_url, params, headers)
         get_charge(route, method_url, params, headers)
         route =~ method_url
-        Data.mock_refund :charge => charges[$1], :refund => params.merge(:balance_transaction => new_balance_transaction('txn'))
+        Data.mock_refund(
+          :charge => charges[$1], :refund => params.merge(:balance_transaction => new_balance_transaction('txn')))
       end
 
     end

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -20,6 +20,18 @@ module StripeMock
         card
       end
 
+      def add_refund_to_charge(refund, charge)
+        refund[:charge] = charge[:id]
+
+        if charge[:refunds][:count] == 0
+          charge[:refunds][:count] += 1
+        end
+
+        charge[:refunds][:data] << refund
+
+        refund
+      end
+
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -1,0 +1,35 @@
+module StripeMock
+  module RequestHandlers
+    module Refunds
+
+      def Refunds.included(klass)
+        klass.add_handler 'get /v1/charges/(.*)/refunds', :retrieve_refunds
+        klass.add_handler 'post /v1/charges/(.*)/refunds', :create_refund
+        klass.add_handler 'get /v1/charges/(.*)/refunds/(.*)', :retrieve_refund
+        klass.add_handler 'post /v1/charges/(.*)/refunds/(.*)', :update_refund
+      end
+
+      def create_refund(route, method_url, params, headers)
+        route =~ method_url
+
+        charge = charges[$1]
+        assert_existance :charge, $1, charge
+
+        refund = Data.mock_refund
+        add_refund_to_charge(refund, charge)
+      end
+
+      def retrieve_refunds(route, method_url, params, headers)
+        # TODO
+      end
+
+      def retrieve_refund(route, method_url, params, headers)
+        # TODO
+      end
+
+      def update_refund(route, method_url, params, headers)
+        # TODO
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -4,7 +4,7 @@ module StripeMock
 
       def Refunds.included(klass)
         klass.add_handler 'get /v1/charges/(.*)/refunds', :retrieve_refunds
-        klass.add_handler 'post /v1/charges/(.*)/refunds', :create_refund
+        klass.add_handler 'post /v1/charges/(.*)/refunds', :create_refund, '2014-06-17'
         klass.add_handler 'get /v1/charges/(.*)/refunds/(.*)', :retrieve_refund
         klass.add_handler 'post /v1/charges/(.*)/refunds/(.*)', :update_refund
       end
@@ -15,7 +15,7 @@ module StripeMock
         charge = charges[$1]
         assert_existance :charge, $1, charge
 
-        refund = Data.mock_refund
+        refund = Data.mock_refund_2014_06_17(params)
         add_refund_to_charge(refund, charge)
       end
 

--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -13,6 +13,7 @@ module StripeMock
         :server => opts[:server] || :thin,
         :show_errors => true
       )
+      StripeMock.version = opts[:"api-version"]
       server.start
     end
 
@@ -29,6 +30,10 @@ module StripeMock
           :error_params => [e.message, e.param, e.http_status, e.http_body, e.json_body]
         }
       end
+    end
+
+    def set_version(version)
+      StripeMock.version = version
     end
 
     def get_data(key)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -8,7 +8,7 @@ describe 'StripeMock Server' do
   end
 
   before(:all) do
-    StripeMock.spawn_server
+    StripeMock.spawn_server(:'api-version' => StripeMock::FIRST_VERSION_DATE)
   end
 
   before do

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -1,44 +1,99 @@
 require 'spec_helper'
 
 shared_examples 'Refund API' do
-  
-  it "refunds a stripe charge item" do
-    charge = Stripe::Charge.create(
-      amount: 999,
-      currency: 'USD',
-      card: 'card_token_abcde',
-      description: 'card charge'
-    )
 
-    charge = charge.refund(amount: 999)
+  context 'with old API (pre 2014-06-17)' do
+    before do
+      StripeMock.version = StripeMock::FIRST_VERSION_DATE
+    end
+    it "refunds a stripe charge item" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
 
-    expect(charge.refunded).to eq(true)
-    expect(charge.refunds.first.amount).to eq(999)
-    expect(charge.amount_refunded).to eq(999)
+      charge = charge.refund(amount: 999)
+
+      expect(charge.refunded).to eq(true)
+      expect(charge.refunds.first.amount).to eq(999)
+      expect(charge.amount_refunded).to eq(999)
+    end
+
+    it "creates a stripe refund with the charge ID" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
+      refund = charge.refund
+
+      expect(charge.id).to match(/^test_ch/)
+      expect(refund.id).to eq(charge.id)
+    end
+
+    it "creates a stripe refund with a different balance transaction than the charge" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
+      refund = charge.refund
+
+      expect(charge.balance_transaction).not_to eq(refund.refunds.first.balance_transaction)
+    end
   end
 
-  it "creates a stripe refund with the charge ID" do
-    charge = Stripe::Charge.create(
-      amount: 999,
-      currency: 'USD',
-      card: 'card_token_abcde',
-      description: 'card charge'
-    )
-    refund = charge.refund
+  context 'with new API (post 2014-06-17)' do
+    before do
+      StripeMock.version = '2014-06-17'
+      StripeMock.client.set_version '2014-06-17' if StripeMock.client
+    end
+    after do
+      StripeMock.version = StripeMock::FIRST_VERSION_DATE
+      StripeMock.client.set_version StripeMock::FIRST_VERSION_DATE if StripeMock.client
+    end
+    it "refunds a stripe charge item" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
 
-    expect(charge.id).to match(/^test_ch/)
-    expect(refund.id).to eq(charge.id)
+      refund = charge.refunds.create(amount: 999)
+
+      expect(refund.id).to match(/test_re/)
+      expect(refund.amount).to eq(999)
+    end
+
+    it "creates a stripe refund with the charge ID" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
+      refund = charge.refunds.create
+
+      expect(charge.id).to match(/^test_ch/)
+      expect(refund.charge).to eq(charge.id)
+    end
+
+    it "creates a stripe refund with a different balance transaction than the charge" do
+      charge = Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        card: 'card_token_abcde',
+        description: 'card charge'
+      )
+      refund = charge.refunds.create
+
+      expect(charge.balance_transaction).not_to eq(refund.balance_transaction)
+    end
   end
 
-  it "creates a stripe refund with a different balance transaction than the charge" do
-    charge = Stripe::Charge.create(
-      amount: 999,
-      currency: 'USD',
-      card: 'card_token_abcde',
-      description: 'card charge'
-    )
-    refund = charge.refund
-
-    expect(charge.balance_transaction).not_to eq(refund.refunds.first.balance_transaction)
-  end
 end


### PR DESCRIPTION
This pull request adds support for refunds, as of API version 2014-06-17[1] 

In order to keep backward compatibility I added a version to api handler.
The idea is that all new backward incompatible handlers, such as
`klass.add_handler 'post /v1/charges/(.*)/refunds', :create_refund, '2014-06-17'`
should have a version defined.

The version is either defined through `--api-version` when running the server through the binstub or if you're not running the server, simply by doing `StripeMock.version = '2014-06-14'`.

The pull request is not 100% ready yet, as you can see the Refund handler class is not finished yet. So let me know if you're ok with my implementation, and if so, I'll wrap up everything so we can merge this.

Again, thanks for this project, it is really helpful for us!

PS: I realize that I should add specs for the `handler_for_method_url` method. I'll try to do that as soon as I can.

[1] https://stripe.com/docs/upgrades#2014-06-17
