### PR TITLE
Add refund id to Refund Data

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -83,6 +83,7 @@ module StripeMock
         refunded: true,
         refunds: [
           {
+            id: 're_00000000000000',
             amount: params[:refund][:amount],
             currency: "usd",
             created: 1380208998,

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 shared_examples 'Refund API' do
-  
+
   it "refunds a stripe charge item" do
     charge = Stripe::Charge.create(
       amount: 999,
@@ -13,6 +13,7 @@ shared_examples 'Refund API' do
     charge = charge.refund(amount: 999)
 
     expect(charge.refunded).to eq(true)
+    expect(charge.refunds.first.id).to match(/^re_/)
     expect(charge.refunds.first.amount).to eq(999)
     expect(charge.amount_refunded).to eq(999)
   end


### PR DESCRIPTION
Simply add a refund_id to the refunds payload.  The Stripe API allows you to interact with said refund id, so it's necessary to have it in order to test many procedural things.
