### PR TITLE
Add limit param to list_invoices

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -25,7 +25,7 @@ module StripeMock
 
       def list_invoices(route, method_url, params, headers)
         params[:offset] ||= 0
-        params[:count] ||= 10
+        params[:count] ||= (params[:limit] || 10)
 
         result = invoices.clone
 

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -65,6 +65,12 @@ shared_examples 'Invoice API' do
         expect(Stripe::Invoice.all(count: 1).count).to eq(1)
       end
     end
+
+    context "when passing limit" do
+      it "gets that many invoices" do
+        expect(Stripe::Invoice.all(limit: 1).count).to eq(1)
+      end
+    end
   end
 
   context "paying an invoice" do


### PR DESCRIPTION
I think this is enough to implement the documented behavior : https://stripe.com/docs/api/curl#list_customer_invoices