### PR TITLE
Allow server to store invoice_items

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -31,7 +31,7 @@ module StripeMock
 
 
     attr_reader :bank_tokens, :charges, :coupons, :customers, :events,
-                :invoices, :plans, :recipients, :subscriptions
+                :invoices, :invoice_items, :plans, :recipients, :subscriptions
 
     attr_accessor :error_queue, :debug, :strict
 
@@ -43,6 +43,7 @@ module StripeMock
       @coupons = {}
       @events = {}
       @invoices = {}
+      @invoice_items = {}
       @plans = {}
       @recipients = {}
       @subscriptions = {}

--- a/lib/stripe_mock/request_handlers/invoice_items.rb
+++ b/lib/stripe_mock/request_handlers/invoice_items.rb
@@ -3,13 +3,27 @@ module StripeMock
     module InvoiceItems
 
       def InvoiceItems.included(klass)
-        klass.add_handler 'post /v1/invoiceitems',  :new_invoice_item
+        klass.add_handler 'post /v1/invoiceitems',      :new_invoice_item
+        klass.add_handler 'get /v1/invoiceitems/(.*)',  :get_invoice_item
+        klass.add_handler 'get /v1/invoiceitems',       :list_invoice_items
       end
 
       def new_invoice_item(route, method_url, params, headers)
-        Data.mock_invoice_item(params)
+        params[:id] ||= new_id('ii')
+        invoice_items[ params[:id] ] = Data.mock_invoice_item(params)
+
+        invoice_items[ params[:id] ]
       end
 
+      def get_invoice_item(route, method_url, params, headers)
+        route =~ method_url
+        assert_existance :invoice_item, $1, invoice_items[$1]
+        invoice_items[$1] ||= Data.mock_invoice_item([], :id => $1)
+      end
+
+      def list_invoice_items(route, method_url, params, headers)
+        invoice_items.values
+      end
     end
   end
 end

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 1.10.1'
+  gem.add_dependency 'stripe', '= 1.15.0'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
This commit allows new invoice items to be retrieved from the server's
data.

Closes #144
