### PR TITLE
Add support for retrieval of invoice line items (invoice.lines.all)

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -5,7 +5,7 @@ module StripeMock
       def Invoices.included(klass)
         klass.add_handler 'post /v1/invoices',               :new_invoice
         klass.add_handler 'get /v1/invoices/upcoming',       :upcoming_invoice
-        klass.add_handler 'get /v1/invoices/(.*)/lines',     :get_invoice_lines
+        klass.add_handler 'get /v1/invoices/(.*)/lines',     :get_invoice_line_items
         klass.add_handler 'get /v1/invoices/(.*)',           :get_invoice
         klass.add_handler 'get /v1/invoices',                :list_invoices
         klass.add_handler 'post /v1/invoices/(.*)/pay',      :pay_invoice
@@ -42,7 +42,7 @@ module StripeMock
         assert_existance :invoice, $1, invoices[$1]
       end
 
-      def get_invoice_lines(route, method_url, params, headers)
+      def get_invoice_line_items(route, method_url, params, headers)
         route =~ method_url
         assert_existance :invoice, $1, invoices[$1]
         invoices[$1][:lines]

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -5,6 +5,7 @@ module StripeMock
       def Invoices.included(klass)
         klass.add_handler 'post /v1/invoices',               :new_invoice
         klass.add_handler 'get /v1/invoices/upcoming',       :upcoming_invoice
+        klass.add_handler 'get /v1/invoices/(.*)/lines',     :get_invoice_lines
         klass.add_handler 'get /v1/invoices/(.*)',           :get_invoice
         klass.add_handler 'get /v1/invoices',                :list_invoices
         klass.add_handler 'post /v1/invoices/(.*)/pay',      :pay_invoice
@@ -41,6 +42,12 @@ module StripeMock
         assert_existance :invoice, $1, invoices[$1]
       end
 
+      def get_invoice_lines(route, method_url, params, headers)
+        route =~ method_url
+        assert_existance :invoice, $1, invoices[$1]
+        invoices[$1][:lines]
+      end
+
       def pay_invoice(route, method_url, params, headers)
         route =~ method_url
         assert_existance :invoice, $1, invoices[$1]
@@ -59,7 +66,9 @@ module StripeMock
         most_recent = customer[:subscriptions][:data].min_by { |sub| sub[:current_period_end] }
         invoice_item = get_mock_subscription_line_item(most_recent)
 
-        Data.mock_invoice([invoice_item],
+        id = new_id('in')
+        invoices[id] = Data.mock_invoice([invoice_item],
+          id: id,
           subscription: most_recent[:id],
           period_start: most_recent[:current_period_start],
           period_end: most_recent[:current_period_end],

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -156,7 +156,7 @@ shared_examples 'Invoice API' do
     end
 
     context 'retrieving invoice line items' do
-      it 'returns all line items for upcoming invoice' do
+      it 'returns all line items for created invoice' do
         @invoice = Stripe::Invoice.create(customer: @customer.id)
         @line_items = @invoice.lines.all
 

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -155,6 +155,32 @@ shared_examples 'Invoice API' do
       expect(@upcoming.subscription).to eq(@shortsub.id)
     end
 
+    context 'retrieving invoice line items' do
+      it 'returns all line items for upcoming invoice' do
+        @invoice = Stripe::Invoice.create(customer: @customer.id)
+        @line_items = @invoice.lines.all
+
+        expect(@invoice).to be_a Stripe::Invoice
+        expect(@line_items.count).to eq(1)
+        expect(@line_items.data[0].object).to eq('line_item')
+        expect(@line_items.data[0].description).to eq('Test invoice item')
+        expect(@line_items.data[0].type).to eq('invoiceitem')
+      end
+
+      it 'returns all line items for upcoming invoice' do
+        @plan = stripe_helper.create_plan()
+        @subscription = @customer.subscriptions.create(plan: @plan.id)
+        @upcoming = Stripe::Invoice.upcoming(customer: @customer.id)
+        @line_items = @upcoming.lines.all
+
+        expect(@upcoming).to be_a Stripe::Invoice
+        expect(@line_items.count).to eq(1)
+        expect(@line_items.data[0].object).to eq('line_item')
+        expect(@line_items.data[0].description).to eq('Test invoice item')
+        expect(@line_items.data[0].type).to eq('subscription')
+      end
+    end
+
     context 'calculates month and year offsets correctly' do
 
       it 'for one month plan on the 1st' do


### PR DESCRIPTION
According to [Stripe API](https://stripe.com/docs/api#invoice_lines), invoice contains only few line items, to get all of them one should call `invoice.lines.all`.

However calling `invoice.lines.all` in stripe-ruby-mock gives me `Stripe::InvalidRequestError:  No such invoice: test_in_5/lines`
