### PR TITLE
Return List objects when scoped to customer

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -100,7 +100,7 @@ module StripeMock
 
     def self.mock_charge_array
       {
-        :data => [test_charge, test_charge, test_charge],
+        :data => [],
         :object => 'list',
         :url => '/v1/charges'
       }
@@ -271,7 +271,7 @@ module StripeMock
 
     def self.mock_invoice_customer_array
       {
-        :data => [test_invoice],
+        :data => [],
         :object => 'list',
         :url => '/v1/invoices?customer=test_customer'
       }

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -29,10 +29,11 @@ module StripeMock
 
         clone = charges.clone
 
-        if params[:customer]
-          clone.delete_if { |k,v| v[:customer] != params[:customer] }
+        if customer_id = params[:customer]
+          clone.delete_if { |k,v| v[:customer] != customer_id }
+          raise Stripe::InvalidRequestError.new("No such customer: #{customer_id}", customer_id, 400) if clone.empty?
+          return Data.mock_charge_array.merge(data: clone.values[params[:offset], params[:count]])
         end
-
         clone.values[params[:offset], params[:count]]
       end
 

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -29,8 +29,10 @@ module StripeMock
 
         result = invoices.clone
 
-        if params[:customer]
-          result.delete_if { |k,v| v[:customer] != params[:customer] }
+        if customer_id = params[:customer]
+          result.delete_if { |k,v| v[:customer] != customer_id }
+          raise Stripe::InvalidRequestError.new("No such customer: #{customer_id}", customer_id, 400) if result.empty?
+          return Data.mock_invoice_customer_array.merge(data: result.values[params[:offset], params[:count]])
         end
 
         result.values[params[:offset], params[:count]]

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -104,6 +104,16 @@ shared_examples 'Charge API' do
       expect(Stripe::Charge.all.count).to eq(10)
     end
 
+    context "when scoped to a customer" do
+      it "raises an error if the customer does not exist" do
+        expect{Stripe::Charge.all(customer: 'not_here')}.to raise_error(Stripe::InvalidRequestError)
+      end
+
+      it "returns a List of charges" do
+        expect(Stripe::Charge.all(customer: @customer.id).data.map(&:id)).to match_array([@charge.id])
+      end
+    end
+
     context "when passing count" do
       it "gets that many charges" do
         expect(Stripe::Charge.all(count: 1).count).to eq(1)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -60,6 +60,16 @@ shared_examples 'Invoice API' do
       expect(Stripe::Invoice.all.count).to eq(10)
     end
 
+    context "when scoped to a customer" do
+      it "raises an error if the customer does not exist" do
+        expect{Stripe::Invoice.all(customer: 'not_here')}.to raise_error(Stripe::InvalidRequestError)
+      end
+
+      it "returns a List of charges" do
+        expect(Stripe::Invoice.all(customer: @customer.id).data.map(&:id)).to match_array([@invoice.id])
+      end
+    end
+
     context "when passing count" do
       it "gets that many invoices" do
         expect(Stripe::Invoice.all(count: 1).count).to eq(1)


### PR DESCRIPTION
When a customer does not exist this will now raise the correct error.  If the customer does exist it will return a list object.