### PR TITLE
allow creation of invoice line items from invoice

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -6,6 +6,7 @@ module StripeMock
         klass.add_handler 'post /v1/invoices',               :new_invoice
         klass.add_handler 'get /v1/invoices/upcoming',       :upcoming_invoice
         klass.add_handler 'get /v1/invoices/(.*)/lines',     :get_invoice_line_items
+        klass.add_handler 'post /v1/invoices/(.*)/lines',     :post_invoice_line_items
         klass.add_handler 'get /v1/invoices/(.*)',           :get_invoice
         klass.add_handler 'get /v1/invoices',                :list_invoices
         klass.add_handler 'post /v1/invoices/(.*)/pay',      :pay_invoice
@@ -46,6 +47,16 @@ module StripeMock
         route =~ method_url
         assert_existance :invoice, $1, invoices[$1]
         invoices[$1][:lines]
+      end
+
+      def post_invoice_line_items(route, method_url, params, headers)
+        params[:id] ||= new_id('ii')
+        route =~ method_url
+        assert_existance :invoice, $1, invoices[$1]
+        invoice_item = Data.mock_line_item(params)
+        invoices[$1][:lines][:data] << invoice_item
+        invoices[$1][:lines][:count] = invoices[$1][:lines][:data].size
+        invoice_item
       end
 
       def pay_invoice(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -182,6 +182,26 @@ shared_examples 'Invoice API' do
       end
     end
 
+    context 'create invoice line item' do
+      it 'adds a line item on an individual invoice' do
+        invoice = Stripe::Invoice.create(customer: @customer.id)
+        line_items = invoice.lines.create(
+          amount: 1_00,
+          description: "Test new line"
+        )
+
+        expect(invoice).to be_a Stripe::Invoice
+        expect(line_items.count).to eq(2)
+        expect(line_items.data[0].object).to eq('line_item')
+        expect(line_items.data[0].description).to eq('Test invoice item')
+        expect(line_items.data[0].type).to eq('invoiceitem')
+        expect(line_items.data[1].object).to eq('line_item')
+        expect(line_items.data[1].description).to eq('Test new line')
+        expect(line_items.data[1].amount).to eq(1_00)
+        expect(line_items.data[1].type).to eq('invoiceitem')
+      end
+    end
+
     context 'calculates month and year offsets correctly' do
 
       it 'for one month plan on the 1st' do


### PR DESCRIPTION
This will allow users to use `invoice.lines.create`