### PR TITLE
Add `tax_percent` to Data.mock_subscription

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -182,6 +182,7 @@ module StripeMock
         :trial_end => 1308681468,
         :customer => "c_test_customer",
         :quantity => 1,
+        :tax_percent => nil,
         :metadata => {}
       }, params)
     end


### PR DESCRIPTION
The field is listed in the API documentation but not in the mocks.

PS: Good job on stripe-ruby-mock, this is incredibly helpful and easy to use.