### PR TITLE
Invalid customer/cards count attribute

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -16,7 +16,7 @@ module StripeMock
         account_balance: 0,
         cards: {
           object: "list",
-          count: cards.count,
+          total_count: cards.size,
           url: "/v1/customers/#{cus_id}/cards",
           data: cards
         },

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -18,7 +18,7 @@ module StripeMock
           object[:cards][:data].delete_if {|card| card[:id] == object[:default_card]}
           object[:default_card] = card[:id]
         else
-          object[:cards][:count] += 1
+          object[:cards][:total_count] += 1
         end
 
         object[:default_card] = card[:id] unless object[:default_card]


### PR DESCRIPTION
Hi there,

I wasn't be able to write my tests properly without this fix. It's related to `count` attribute in `customer/cards` object which should be replaced by `total_count`. Also I wasn't be able to increase number of cards because of this wrong attribute.

https://stripe.com/docs/api#retrieve_customer