### PR TITLE
List objects and pagination

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -5,10 +5,11 @@ require 'dante'
 require 'stripe'
 
 require 'stripe_mock/version'
-require 'stripe_mock/data'
-require 'stripe_mock/list'
 require 'stripe_mock/util'
 require 'stripe_mock/error_queue'
+
+require 'stripe_mock/data'
+require 'stripe_mock/data/list'
 
 require 'stripe_mock/errors/stripe_mock_error'
 require 'stripe_mock/errors/unsupported_request_error'

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -6,6 +6,7 @@ require 'stripe'
 
 require 'stripe_mock/version'
 require 'stripe_mock/data'
+require 'stripe_mock/list'
 require 'stripe_mock/util'
 require 'stripe_mock/error_queue'
 

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -440,5 +440,10 @@ module StripeMock
         :id => "di_test_coupon"
       }
     end
+
+    def self.mock_list_object(data, params = {})
+      list = StripeMock::Data::List.new(data, params)
+      list.to_h
+    end
   end
 end

--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -5,7 +5,7 @@ module StripeMock
 
       def initialize(data, options = {})
         @data = Array(data.clone)
-        @limit = [[options[:limit] || 10, 100].min, 1].max
+        @limit = [[options[:limit] || 10, 100].min, 1].max # restrict @limit to 1..100
         @starting_after = options[:starting_after]
       end
 
@@ -38,7 +38,6 @@ module StripeMock
 
       private
 
-      # TODO: REFACTOR
       def offset
         if starting_after
           if index = data.index { |datum| datum.id == starting_after }

--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -22,6 +22,20 @@ module StripeMock
         (offset + limit) < data.size
       end
 
+      def method_missing(method_name, *args, &block)
+        hash = to_hash
+
+        if hash.keys.include?(method_name)
+          hash[method_name]
+        else
+          super
+        end
+      end
+
+      def respond_to?(method_name, priv = false)
+        to_hash.keys.include?(method_name) || super
+      end
+
       private
 
       # TODO: REFACTOR

--- a/lib/stripe_mock/list.rb
+++ b/lib/stripe_mock/list.rb
@@ -1,0 +1,51 @@
+module StripeMock
+  module Data
+    class List
+      attr_reader :data, :limit, :offset, :starting_after
+
+      def initialize(data, options = {})
+        @data = Array(data.clone)
+        @limit = [[options[:limit] || 10, 100].min, 1].max
+        @starting_after = options[:starting_after]
+      end
+
+      def url
+        "/v1/#{object_types}"
+      end
+
+      def to_hash
+        { object: "list", data: data_page, url: url, has_more: has_more? }
+      end
+      alias_method :to_h, :to_hash
+
+      def has_more?
+        (offset + limit) < data.size
+      end
+
+      private
+
+      # TODO: REFACTOR
+      def offset
+        if starting_after
+          if index = data.index { |datum| datum.id == starting_after }
+            index + 1
+          else
+            raise "No such object id: #{starting_after}"
+          end
+        else
+          0
+        end
+      end
+
+      def data_page
+        data[offset, limit]
+      end
+
+      def object_types
+        if first_object = data[0]
+          "#{first_object.class.to_s.split('::')[-1].downcase}s"
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -22,10 +22,9 @@ module StripeMock
       def retrieve_cards(route, method_url, params, headers)
         route =~ method_url
         customer = assert_existence :customer, $1, customers[$1]
-
         cards = customer[:cards]
-        cards[:count] = cards[:data].length
-        cards
+
+        Data.mock_list_object(cards[:data])
       end
 
       def retrieve_card(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -32,7 +32,7 @@ module StripeMock
 
       def get_charges(route, method_url, params, headers)
         params[:offset] ||= 0
-        params[:count] ||= 10
+        params[:limit] ||= 10
 
         clone = charges.clone
 
@@ -40,7 +40,7 @@ module StripeMock
           clone.delete_if { |k,v| v[:customer] != params[:customer] }
         end
 
-        clone.values[params[:offset], params[:count]]
+        Data.mock_list_object(clone.values, params)
       end
 
       def get_charge(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/coupons.rb
+++ b/lib/stripe_mock/request_handlers/coupons.rb
@@ -25,7 +25,7 @@ module StripeMock
       end
 
       def list_coupons(route, method_url, params, headers)
-        coupons.values
+        Data.mock_list_object(coupons.values, params)
       end
 
     end

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -69,7 +69,7 @@ module StripeMock
       end
 
       def list_customers(route, method_url, params, headers)
-        customers.values
+        Data.mock_list_object(customers.values, params)
       end
 
     end

--- a/lib/stripe_mock/request_handlers/invoice_items.rb
+++ b/lib/stripe_mock/request_handlers/invoice_items.rb
@@ -32,7 +32,7 @@ module StripeMock
       end
 
       def list_invoice_items(route, method_url, params, headers)
-        invoice_items.values
+        Data.mock_list_object(invoice_items.values, params)
       end
 
       def get_invoice_item(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -26,7 +26,7 @@ module StripeMock
 
       def list_invoices(route, method_url, params, headers)
         params[:offset] ||= 0
-        params[:count] ||= 10
+        params[:limit] ||= 10
 
         result = invoices.clone
 
@@ -34,7 +34,7 @@ module StripeMock
           result.delete_if { |k,v| v[:customer] != params[:customer] }
         end
 
-        result.values[params[:offset], params[:count]]
+        Data.mock_list_object(result.values, params)
       end
 
       def get_invoice(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/plans.rb
+++ b/lib/stripe_mock/request_handlers/plans.rb
@@ -32,7 +32,7 @@ module StripeMock
       end
 
       def list_plans(route, method_url, params, headers)
-        plans.values
+        Data.mock_list_object(plans.values)
       end
 
     end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -47,6 +47,17 @@ describe StripeMock::Data::List do
     )
   end
 
+  it "delegates other methods to hash keys" do
+    list = StripeMock::Data::List.new([double, double, double])
+
+    expect(list).to respond_to(:data)
+    expect(list.data).to be_kind_of(Array)
+    expect(list.object).to eq("list")
+    expect(list.has_more).to eq(false)
+    expect(list.url).to eq("/v1/doubles")
+    expect { list.foobar }.to raise_error(NoMethodError)
+  end
+
   context "with a limit" do
     it "accepts a limit which is reflected in the data returned" do
       list = StripeMock::Data::List.new([double] * 25)

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+describe StripeMock::Data::List do
+  before :all do
+    StripeMock.start
+  end
+
+  after :all do
+    StripeMock.stop
+  end
+
+  it "contains data" do
+    obj = double
+    obj2 = double
+    obj3 = double
+    list = StripeMock::Data::List.new([obj, obj2, obj3])
+
+    expect(list.data).to eq([obj, obj2, obj3])
+  end
+
+  it "can accept a single object" do
+    list = StripeMock::Data::List.new(double)
+
+    expect(list.data).to be_kind_of(Array)
+    expect(list.data.size).to eq(1)
+  end
+
+  it "infers object type for url" do
+    customer = Stripe::Customer.create
+    list = StripeMock::Data::List.new([customer])
+
+    expect(list.url).to eq("/v1/customers")
+  end
+
+  it "eventually gets turned into a hash" do
+    charge1 = Stripe::Charge.create
+    charge2 = Stripe::Charge.create
+    charge3 = Stripe::Charge.create
+    list = StripeMock::Data::List.new([charge1, charge2, charge3])
+    hash = list.to_h
+
+    expect(hash).to eq(
+      object: "list",
+      data: [charge1, charge2, charge3],
+      url: "/v1/charges",
+      has_more: false
+    )
+  end
+
+  context "with a limit" do
+    it "accepts a limit which is reflected in the data returned" do
+      list = StripeMock::Data::List.new([double] * 25)
+
+      expect(list.to_h[:data].size).to eq(10)
+
+      list = StripeMock::Data::List.new([double] * 25, limit: 15)
+
+      expect(list.limit).to eq(15)
+      expect(list.to_h[:data].size).to eq(15)
+    end
+
+    it "defaults to a limit of 10" do
+      list = StripeMock::Data::List.new([])
+
+      expect(list.limit).to eq(10)
+    end
+
+    it "won't accept a limit of > 100" do
+      list = StripeMock::Data::List.new([], limit: 105)
+
+      expect(list.limit).to eq(100)
+    end
+
+    it "won't accept a limit of < 1" do
+      list = StripeMock::Data::List.new([], limit: 0)
+
+      expect(list.limit).to eq(1)
+
+      list = StripeMock::Data::List.new([], limit: -4)
+
+      expect(list.limit).to eq(1)
+    end
+  end
+
+  context "pagination" do
+    it "has a has_more field when it has more" do
+      list = StripeMock::Data::List.new([Stripe::Charge.create] * 256)
+
+      expect(list).to have_more
+    end
+
+    it "accepts a starting_after parameter" do
+      data = []
+      255.times { data << Stripe::Charge.create }
+      new_charge = Stripe::Charge.create
+      data[89] = new_charge
+      list = StripeMock::Data::List.new(data, starting_after: "test_ch_261")
+      hash = list.to_h
+
+      expect(hash[:data].size).to eq(10)
+      expect(hash[:data]).to eq(data[90, 10])
+    end
+
+    it "raises an error if starting_after cursor is not found" do
+      data = []
+      255.times { data << Stripe::Charge.create }
+      list = StripeMock::Data::List.new(data, starting_after: "test_ch_unknown")
+
+      expect { list.to_h }.to raise_error
+    end
+  end
+end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -105,7 +105,7 @@ describe StripeMock::Data::List do
       255.times { data << Stripe::Charge.create }
       new_charge = Stripe::Charge.create
       data[89] = new_charge
-      list = StripeMock::Data::List.new(data, starting_after: "test_ch_261")
+      list = StripeMock::Data::List.new(data, starting_after: new_charge.id)
       hash = list.to_h
 
       expect(hash[:data].size).to eq(10)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -132,6 +132,12 @@ shared_examples 'Charge API' do
       expect(Stripe::Charge.all.data.count).to eq(10)
     end
 
+    it "is marked as having more when more objects exist" do
+      11.times { Stripe::Charge.create }
+
+      expect(Stripe::Charge.all.has_more).to eq(true)
+    end
+
     context "when passing limit" do
       it "gets that many charges" do
         expect(Stripe::Charge.all(limit: 1).count).to eq(1)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -120,21 +120,21 @@ shared_examples 'Charge API' do
     end
 
     it "stores charges for a customer in memory" do
-      expect(@customer.charges.map(&:id)).to eq([@charge.id])
+      expect(@customer.charges.data.map(&:id)).to eq([@charge.id])
     end
 
     it "stores all charges in memory" do
-      expect(Stripe::Charge.all.map(&:id)).to eq([@charge.id, @charge2.id])
+      expect(Stripe::Charge.all.data.map(&:id)).to eq([@charge.id, @charge2.id])
     end
 
     it "defaults count to 10 charges" do
       11.times { Stripe::Charge.create }
-      expect(Stripe::Charge.all.count).to eq(10)
+      expect(Stripe::Charge.all.data.count).to eq(10)
     end
 
-    context "when passing count" do
+    context "when passing limit" do
       it "gets that many charges" do
-        expect(Stripe::Charge.all(count: 1).count).to eq(1)
+        expect(Stripe::Charge.all(limit: 1).count).to eq(1)
       end
     end
   end

--- a/spec/shared_stripe_examples/coupon_examples.rb
+++ b/spec/shared_stripe_examples/coupon_examples.rb
@@ -88,7 +88,7 @@ shared_examples 'Coupon API' do
     Stripe::Coupon.create({ id: 'Coupon Two', amount_off: 3000 })
 
     all = Stripe::Coupon.all
-    expect(all.length).to eq(2)
+    expect(all.count).to eq(2)
     expect(all.map &:id).to include('Coupon One', 'Coupon Two')
     expect(all.map &:amount_off).to include(1500, 3000)
   end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -197,7 +197,7 @@ shared_examples 'Customer API' do
     Stripe::Customer.create({ email: 'two@two.com' })
 
     all = Stripe::Customer.all
-    expect(all.length).to eq(2)
+    expect(all.count).to eq(2)
     expect(all.map &:email).to include('one@one.com', 'two@two.com')
   end
 

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -66,7 +66,7 @@ shared_examples 'Invoice API' do
       expect(Stripe::Invoice.all.has_more).to eq(true)
     end
 
-    context "when passing count" do
+    context "when passing limit" do
       it "gets that many invoices" do
         expect(Stripe::Invoice.all(limit: 1).count).to eq(1)
       end

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -60,6 +60,12 @@ shared_examples 'Invoice API' do
       expect(Stripe::Invoice.all.count).to eq(10)
     end
 
+    it "is marked as having more when more objects exist" do
+      11.times { Stripe::Invoice.create }
+
+      expect(Stripe::Invoice.all.has_more).to eq(true)
+    end
+
     context "when passing count" do
       it "gets that many invoices" do
         expect(Stripe::Invoice.all(limit: 1).count).to eq(1)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -62,7 +62,7 @@ shared_examples 'Invoice API' do
 
     context "when passing count" do
       it "gets that many invoices" do
-        expect(Stripe::Invoice.all(count: 1).count).to eq(1)
+        expect(Stripe::Invoice.all(limit: 1).count).to eq(1)
       end
     end
   end

--- a/spec/shared_stripe_examples/invoice_item_examples.rb
+++ b/spec/shared_stripe_examples/invoice_item_examples.rb
@@ -40,7 +40,7 @@ shared_examples 'Invoice Item API' do
 
     it "retrieves all invoice items" do
       all = Stripe::InvoiceItem.all
-      expect(all.length).to eq(2)
+      expect(all.count).to eq(2)
       expect(all.map &:amount).to include(1075, 1540)
     end
   end

--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -96,7 +96,7 @@ shared_examples 'Plan API' do
     stripe_helper.create_plan(id: 'Plan Two', amount: 98765)
 
     all = Stripe::Plan.all
-    expect(all.length).to eq(2)
+    expect(all.count).to eq(2)
     expect(all.map &:id).to include('Plan One', 'Plan Two')
     expect(all.map &:amount).to include(54321, 98765)
   end


### PR DESCRIPTION
There's a bunch of responses that StripeMock returns which are simply arrays, not lists like the live Stripe API returns. There are a some issues opened about this, including some PRs which patch only parts of this (e.g. #161, #151, #160). This provides a common `List` class which can wrap any array of mock Stripe objects into a list and additionally add pagination functionality