### PR TITLE
Allow tests to retrieve webhook payloads and not just Stripe::Events

### DIFF
--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -1,6 +1,6 @@
 module StripeMock
 
-  def self.mock_webhook_event(type, params={})
+  def self.mock_webhook_payload(type, params = {})
 
     fixture_file = File.join(@webhook_fixture_path, "#{type}.json")
 
@@ -25,8 +25,11 @@ module StripeMock
     else
       raise UnstartedStateError
     end
+    event_data
+  end
 
-    Stripe::Event.construct_from(event_data)
+  def self.mock_webhook_event(type, params={})
+    Stripe::Event.construct_from(mock_webhook_payload(type, params))
   end
 
   module Webhooks


### PR DESCRIPTION
With this change, people can easily get the webhook payload to test their handlers without having an Stripe::Event object.

It's basically extracting reading the json files to its own method instead of having them in the `mock_webhook_event`.