### PR TITLE
Allow adding and cards to recipients

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -315,9 +315,9 @@ module StripeMock
         },
         cards: {
           object: "list",
-          count: cards.count,
           url: "/v1/recipients/#{rp_id}/cards",
-          data: cards
+          data: cards,
+          total_count: cards.count
         },
         default_card: nil
       }.merge(params)

--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -9,6 +9,7 @@ module StripeMock
         klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_card
         klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_card
         klass.add_handler 'get /v1/recipients/(.*)/cards/(.*)', :retrieve_recipient_card
+        klass.add_handler 'post /v1/recipients/(.*)/cards', :create_recipient_card
       end
 
       def create_card(route, method_url, params, headers)
@@ -17,6 +18,14 @@ module StripeMock
 
         card = card_from_params(params[:card])
         add_card_to_object(:customer, card, customer)
+      end
+
+      def create_recipient_card(route, method_url, params, headers)
+        route =~ method_url
+        recipient = assert_existence :recipient, $1, recipients[$1]
+
+        card = card_from_params(params[:card])
+        add_card_to_object(:recipient, card, recipient)
       end
 
       def retrieve_cards(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -10,6 +10,7 @@ module StripeMock
         klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_card
         klass.add_handler 'get /v1/recipients/(.*)/cards/(.*)', :retrieve_recipient_card
         klass.add_handler 'post /v1/recipients/(.*)/cards', :create_recipient_card
+        klass.add_handler 'delete /v1/recipients/(.*)/cards/(.*)', :delete_recipient_card
       end
 
       def create_card(route, method_url, params, headers)
@@ -61,6 +62,20 @@ module StripeMock
           cc[:id] == card[:id]
         }
         customer[:default_card] = customer[:cards][:data].count > 0 ? customer[:cards][:data].first[:id] : nil
+        card
+      end
+
+      def delete_recipient_card(route, method_url, params, headers)
+        route =~ method_url
+        recipient = assert_existence :recipient, $1, recipients[$1]
+
+        assert_existence :card, $2, get_card(recipient, $2)
+
+        card = { id: $2, deleted: true }
+        recipient[:cards][:data].reject!{|cc|
+          cc[:id] == card[:id]
+        }
+        recipient[:default_card] = recipient[:cards][:data].count > 0 ? recipient[:cards][:data].first[:id] : nil
         card
       end
 

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -150,6 +150,42 @@ shared_examples 'Card API' do
       expect(retrieved_cus.default_card).to be_nil
     end
 
+    context "for recipient cards" do
+      let!(:recipient) { Stripe::Recipient.create(id: 'test_recipient_sub') }
+      let!(:card_token) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+      let!(:card) { recipient.cards.create(card: card_token) }
+
+      it "deletes a recipient card" do
+        card.delete
+        retrieved_cus = Stripe::Recipient.retrieve(recipient.id)
+        expect(retrieved_cus.cards.data).to be_empty
+      end
+
+      it "deletes a recipient card then set the default_card to nil" do
+        card.delete
+        retrieved_cus = Stripe::Recipient.retrieve(recipient.id)
+        expect(retrieved_cus.default_card).to be_nil
+      end
+
+      context "deletion when the recipient has two cards" do
+        let!(:card_token_2) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+        let!(:card_2) { recipient.cards.create(card: card_token_2) }
+
+        it "has just one card anymore" do
+          card.delete
+          retrieved_rec = Stripe::Recipient.retrieve(recipient.id)
+          expect(retrieved_rec.cards.data.count).to eq 1
+          expect(retrieved_rec.cards.data.first.id).to eq card_2.id
+        end
+
+        it "sets the default_card id to the last card remaining id" do
+          card.delete
+          retrieved_rec = Stripe::Recipient.retrieve(recipient.id)
+          expect(retrieved_rec.default_card).to eq card_2.id
+        end
+      end
+    end
+
     context "deletion when the user has two cards" do
       let!(:card_token_2) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
       let!(:card_2) { customer.cards.create(card: card_token_2) }

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -21,6 +21,25 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(2099)
   end
 
+  it 'creates/returns a card when using recipient.cards.create given a card token' do
+    recipient = Stripe::Recipient.create(id: 'test_recipient_sub')
+    card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
+    card = recipient.cards.create(card: card_token)
+
+    expect(card.recipient).to eq('test_recipient_sub')
+    expect(card.last4).to eq("1123")
+    expect(card.exp_month).to eq(11)
+    expect(card.exp_year).to eq(2099)
+
+    recipient = Stripe::Recipient.retrieve('test_recipient_sub')
+    expect(recipient.cards.count).to eq(1)
+    card = recipient.cards.data.first
+    expect(card.recipient).to eq('test_recipient_sub')
+    expect(card.last4).to eq("1123")
+    expect(card.exp_month).to eq(11)
+    expect(card.exp_year).to eq(2099)
+  end
+
   it 'creates/returns a card when using customer.cards.create given card params' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     card = customer.cards.create(card: {
@@ -44,6 +63,28 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(3031)
   end
 
+  it 'creates/returns a card when using recipient.cards.create given card params' do
+    recipient = Stripe::Recipient.create(id: 'test_recipient_sub')
+    card = recipient.cards.create(card: {
+      number: '4000056655665556',
+      exp_month: '11',
+      exp_year: '3031',
+      cvc: '123'
+    })
+
+    expect(card.recipient).to eq('test_recipient_sub')
+    expect(card.last4).to eq("5556")
+    expect(card.exp_month).to eq(11)
+    expect(card.exp_year).to eq(3031)
+
+    recipient = Stripe::Recipient.retrieve('test_recipient_sub')
+    expect(recipient.cards.count).to eq(1)
+    card = recipient.cards.data.first
+    expect(card.recipient).to eq('test_recipient_sub')
+    expect(card.last4).to eq("5556")
+    expect(card.exp_month).to eq(11)
+    expect(card.exp_year).to eq(3031)
+  end
 
   it "creates a single card with a generated card token", :live => true do
     customer = Stripe::Customer.create


### PR DESCRIPTION
With this commit you can now do `recipient.cards.create(card: token)` and `recipient.cards.retrieve(token).delete`.