### PR TITLE
Subscriptions attribute count to total_count

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -22,7 +22,7 @@ module StripeMock
         },
         subscriptions: {
           object: "list",
-          count: 0,
+          total_count: 0,
           url: "/v1/customers/#{cus_id}/subscriptions",
           data: []
         },

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -26,7 +26,7 @@ module StripeMock
       end
 
       def add_subscription_to_customer(cus, sub)
-        cus[:subscriptions][:count] = (cus[:subscriptions][:count] || 0) + 1
+        cus[:subscriptions][:total_count] = (cus[:subscriptions][:total_count] || 0) + 1
         cus[:subscriptions][:data].unshift sub
       end
 
@@ -34,7 +34,7 @@ module StripeMock
         cus[:subscriptions][:data].reject!{|sub|
           sub[:id] == subscription[:id]
         }
-        cus[:subscriptions][:count] -=1
+        cus[:subscriptions][:total_count] -=1
       end
 
       # `intervals` is set to 1 when calculating current_period_end from current_period_start & plan


### PR DESCRIPTION
The major stripe upgrade of 2014-03-28 replaced the lists attribute with an optional total_count. Updated subscriptions to reflect this change.

https://stripe.com/docs/upgrades#2014-03-28