### PR TITLE
Add `forgiven` to Data.mock_invoice

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -209,6 +209,7 @@ module StripeMock
         object: 'invoice',
         attempted: false,
         closed: false,
+        forgiven: false,
         paid: false,
         livemode: false,
         attempt_count: 0,


### PR DESCRIPTION
Fixes https://github.com/rebelidealist/stripe-ruby-mock/issues/175