### PR TITLE
Disallow Stripe::Charge without required params or non positive-integer amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ it "mocks a declined card error" do
   # Prepares an error for the next create charge request
   StripeMock.prepare_card_error(:card_declined)
 
-  expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
+  expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error {|e|
     expect(e).to be_a Stripe::CardError
     expect(e.http_status).to eq(402)
     expect(e.code).to eq('card_declined')
@@ -171,7 +171,7 @@ it "raises a custom error for specific actions" do
 
   StripeMock.prepare_error(custom_error, :new_customer)
 
-  expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
+  expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to_not raise_error
   expect { Stripe::Customer.create }.to raise_error {|e|
     expect(e).to be_a StandardError
     expect(e.message).to eq("Please knock first.")

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ it "mocks a declined card error" do
   # Prepares an error for the next create charge request
   StripeMock.prepare_card_error(:card_declined)
 
-  expect { Stripe::Charge.create }.to raise_error {|e|
+  expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
     expect(e).to be_a Stripe::CardError
     expect(e.http_status).to eq(402)
     expect(e.code).to eq('card_declined')
@@ -171,7 +171,7 @@ it "raises a custom error for specific actions" do
 
   StripeMock.prepare_error(custom_error, :new_customer)
 
-  expect { Stripe::Charge.create }.to_not raise_error
+  expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
   expect { Stripe::Customer.create }.to raise_error {|e|
     expect(e).to be_a StandardError
     expect(e.message).to eq("Please knock first.")

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -14,10 +14,6 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
 
-        if params[:amount] && !params[:amount].is_a?(Integer) || params[:amount] < 1
-          raise Stripe::InvalidRequestError.new("Invalid positive integer", 'amount', 400)
-        end
-
         if params[:card] && params[:card].is_a?(String)
           # if a customer is provided, the card parameter is assumed to be the actual
           # card id, not a token. in this case we'll find the card in the customer
@@ -29,6 +25,12 @@ module StripeMock
           end
         elsif params[:card] && params[:card][:id]
           raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:card]}", 'card', 400)
+        end
+
+        if params[:amount] && !params[:amount].is_a?(Integer)
+          raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', 400)
+        elsif params[:amount] && params[:amount] < 1
+          raise Stripe::InvalidRequestError.new("Invalid positive integer", 'amount', 400)
         end
 
         charges[id] = Data.mock_charge(params.merge :id => id, :balance_transaction => new_balance_transaction('txn'))

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -93,7 +93,11 @@ module StripeMock
       private
 
       def ensure_required_params(params)
-        if non_integer_charge_amount?(params)
+        if params[:amount].nil?
+          require_param(:amount)
+        elsif params[:currency].nil?
+          require_param(:currency)
+        elsif non_integer_charge_amount?(params)
           raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', 400)
         elsif non_positive_charge_amount?(params)
           raise Stripe::InvalidRequestError.new('Invalid positive integer', 'amount', 400)
@@ -106,6 +110,10 @@ module StripeMock
 
       def non_positive_charge_amount?(params)
         params[:amount] && params[:amount] < 1
+      end
+
+      def require_param(param)
+        raise Stripe::InvalidRequestError.new("Missing required param: #{param}", param.to_s, 400)
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -14,6 +14,10 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
 
+        if params[:amount] && !params[:amount].is_a?(Integer) || params[:amount] < 1
+          raise Stripe::InvalidRequestError.new("Invalid positive integer", 'amount', 400)
+        end
+
         if params[:card] && params[:card].is_a?(String)
           # if a customer is provided, the card parameter is assumed to be the actual
           # card id, not a token. in this case we'll find the card in the customer

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -27,11 +27,7 @@ module StripeMock
           raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:card]}", 'card', 400)
         end
 
-        if params[:amount] && !params[:amount].is_a?(Integer)
-          raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', 400)
-        elsif params[:amount] && params[:amount] < 1
-          raise Stripe::InvalidRequestError.new("Invalid positive integer", 'amount', 400)
-        end
+        ensure_required_params(params)
 
         charges[id] = Data.mock_charge(params.merge :id => id, :balance_transaction => new_balance_transaction('txn'))
       end
@@ -94,6 +90,23 @@ module StripeMock
         refund
       end
 
+      private
+
+      def ensure_required_params(params)
+        if non_integer_charge_amount?(params)
+          raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', 400)
+        elsif non_positive_charge_amount?(params)
+          raise Stripe::InvalidRequestError.new('Invalid positive integer', 'amount', 400)
+        end
+      end
+
+      def non_integer_charge_amount?(params)
+        params[:amount] && !params[:amount].is_a?(Integer)
+      end
+
+      def non_positive_charge_amount?(params)
+        params[:amount] && params[:amount] < 1
+      end
     end
   end
 end

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -33,9 +33,9 @@ describe StripeMock::Data::List do
   end
 
   it "eventually gets turned into a hash" do
-    charge1 = Stripe::Charge.create(amount: 1)
-    charge2 = Stripe::Charge.create(amount: 1)
-    charge3 = Stripe::Charge.create(amount: 1)
+    charge1 = Stripe::Charge.create(amount: 1, currency: 'usd')
+    charge2 = Stripe::Charge.create(amount: 1, currency: 'usd')
+    charge3 = Stripe::Charge.create(amount: 1, currency: 'usd')
     list = StripeMock::Data::List.new([charge1, charge2, charge3])
     hash = list.to_h
 
@@ -95,15 +95,15 @@ describe StripeMock::Data::List do
 
   context "pagination" do
     it "has a has_more field when it has more" do
-      list = StripeMock::Data::List.new([Stripe::Charge.create(amount: 1)] * 256)
+      list = StripeMock::Data::List.new([Stripe::Charge.create(amount: 1, currency: 'usd')] * 256)
 
       expect(list).to have_more
     end
 
     it "accepts a starting_after parameter" do
       data = []
-      255.times { data << Stripe::Charge.create(amount: 1) }
-      new_charge = Stripe::Charge.create(amount: 1)
+      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd') }
+      new_charge = Stripe::Charge.create(amount: 1, currency: 'usd')
       data[89] = new_charge
       list = StripeMock::Data::List.new(data, starting_after: new_charge.id)
       hash = list.to_h
@@ -114,7 +114,7 @@ describe StripeMock::Data::List do
 
     it "raises an error if starting_after cursor is not found" do
       data = []
-      255.times { data << Stripe::Charge.create(amount: 1) }
+      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd') }
       list = StripeMock::Data::List.new(data, starting_after: "test_ch_unknown")
 
       expect { list.to_h }.to raise_error

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -33,9 +33,9 @@ describe StripeMock::Data::List do
   end
 
   it "eventually gets turned into a hash" do
-    charge1 = Stripe::Charge.create
-    charge2 = Stripe::Charge.create
-    charge3 = Stripe::Charge.create
+    charge1 = Stripe::Charge.create(amount: 1)
+    charge2 = Stripe::Charge.create(amount: 1)
+    charge3 = Stripe::Charge.create(amount: 1)
     list = StripeMock::Data::List.new([charge1, charge2, charge3])
     hash = list.to_h
 
@@ -95,15 +95,15 @@ describe StripeMock::Data::List do
 
   context "pagination" do
     it "has a has_more field when it has more" do
-      list = StripeMock::Data::List.new([Stripe::Charge.create] * 256)
+      list = StripeMock::Data::List.new([Stripe::Charge.create(amount: 1)] * 256)
 
       expect(list).to have_more
     end
 
     it "accepts a starting_after parameter" do
       data = []
-      255.times { data << Stripe::Charge.create }
-      new_charge = Stripe::Charge.create
+      255.times { data << Stripe::Charge.create(amount: 1) }
+      new_charge = Stripe::Charge.create(amount: 1)
       data[89] = new_charge
       list = StripeMock::Data::List.new(data, starting_after: new_charge.id)
       hash = list.to_h
@@ -114,7 +114,7 @@ describe StripeMock::Data::List do
 
     it "raises an error if starting_after cursor is not found" do
       data = []
-      255.times { data << Stripe::Charge.create }
+      255.times { data << Stripe::Charge.create(amount: 1) }
       list = StripeMock::Data::List.new(data, starting_after: "test_ch_unknown")
 
       expect { list.to_h }.to raise_error

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -20,7 +20,7 @@ describe 'README examples' do
     # Prepares an error for the next create charge request
     StripeMock.prepare_card_error(:card_declined)
 
-    expect { Stripe::Charge.create }.to raise_error {|e|
+    expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
       expect(e).to be_a Stripe::CardError
       expect(e.http_status).to eq(402)
       expect(e.code).to eq('card_declined')

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -20,7 +20,7 @@ describe 'README examples' do
     # Prepares an error for the next create charge request
     StripeMock.prepare_card_error(:card_declined)
 
-    expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
+    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error {|e|
       expect(e).to be_a Stripe::CardError
       expect(e.http_status).to eq(402)
       expect(e.code).to eq('card_declined')

--- a/spec/shared_stripe_examples/card_token_examples.rb
+++ b/spec/shared_stripe_examples/card_token_examples.rb
@@ -7,7 +7,7 @@ shared_examples 'Card Token Mocking' do
     it "generates and reads a card token for create charge" do
       card_token = StripeMock.generate_card_token(last4: "2244", exp_month: 33, exp_year: 2255)
 
-      charge = Stripe::Charge.create(amount: 500, card: card_token)
+      charge = Stripe::Charge.create(amount: 500, currency: 'usd', card: card_token)
       card = charge.card
       expect(card.last4).to eq("2244")
       expect(card.exp_month).to eq(33)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -12,6 +12,24 @@ shared_examples 'Charge API' do
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
   end
 
+  it "requires presence of amount", :live => true do
+    expect {
+      charge = Stripe::Charge.create(
+        currency: 'usd',
+        card: stripe_helper.generate_card_token
+      )
+    }.to raise_error(Stripe::InvalidRequestError, /missing required param: amount/i)
+  end
+
+  it "requires presence of currency", :live => true do
+    expect {
+      charge = Stripe::Charge.create(
+        amount: 99,
+        card: stripe_helper.generate_card_token
+      )
+    }.to raise_error(Stripe::InvalidRequestError, /missing required param: currency/i)
+  end
+
   it "requires a valid positive amount", :live => true do
     expect {
       charge = Stripe::Charge.create(
@@ -135,8 +153,8 @@ shared_examples 'Charge API' do
   context "retrieving a list of charges" do
     before do
       @customer = Stripe::Customer.create(email: 'johnny@appleseed.com')
-      @charge = Stripe::Charge.create(amount: 1, customer: @customer.id)
-      @charge2 = Stripe::Charge.create(amount: 1)
+      @charge = Stripe::Charge.create(amount: 1, currency: 'usd', customer: @customer.id)
+      @charge2 = Stripe::Charge.create(amount: 1, currency: 'usd')
     end
 
     it "stores charges for a customer in memory" do
@@ -148,12 +166,12 @@ shared_examples 'Charge API' do
     end
 
     it "defaults count to 10 charges" do
-      11.times { Stripe::Charge.create(amount: 1) }
+      11.times { Stripe::Charge.create(amount: 1, currency: 'usd') }
       expect(Stripe::Charge.all.data.count).to eq(10)
     end
 
     it "is marked as having more when more objects exist" do
-      11.times { Stripe::Charge.create(amount: 1) }
+      11.times { Stripe::Charge.create(amount: 1, currency: 'usd') }
 
       expect(Stripe::Charge.all.has_more).to eq(true)
     end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -12,6 +12,26 @@ shared_examples 'Charge API' do
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
   end
 
+  it "requires a valid positive amount", :live => true do
+    expect {
+      charge = Stripe::Charge.create(
+        amount: -99,
+        currency: 'usd',
+        card: 'bogus_card_token'
+      )
+    }.to raise_error(Stripe::InvalidRequestError, /integer/i)
+  end
+
+  it "requires a valid integer amount", :live => true do
+    expect {
+      charge = Stripe::Charge.create(
+        amount: 99.0,
+        currency: 'usd',
+        card: 'bogus_card_token'
+      )
+    }.to raise_error(Stripe::InvalidRequestError, /integer/i)
+  end
+
   it "creates a stripe charge item with a card token" do
     charge = Stripe::Charge.create(
       amount: 999,
@@ -115,8 +135,8 @@ shared_examples 'Charge API' do
   context "retrieving a list of charges" do
     before do
       @customer = Stripe::Customer.create(email: 'johnny@appleseed.com')
-      @charge = Stripe::Charge.create(customer: @customer.id)
-      @charge2 = Stripe::Charge.create
+      @charge = Stripe::Charge.create(amount: 1, customer: @customer.id)
+      @charge2 = Stripe::Charge.create(amount: 1)
     end
 
     it "stores charges for a customer in memory" do
@@ -128,12 +148,12 @@ shared_examples 'Charge API' do
     end
 
     it "defaults count to 10 charges" do
-      11.times { Stripe::Charge.create }
+      11.times { Stripe::Charge.create(amount: 1) }
       expect(Stripe::Charge.all.data.count).to eq(10)
     end
 
     it "is marked as having more when more objects exist" do
-      11.times { Stripe::Charge.create }
+      11.times { Stripe::Charge.create(amount: 1) }
 
       expect(Stripe::Charge.all.has_more).to eq(true)
     end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -17,9 +17,9 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create(
         amount: -99,
         currency: 'usd',
-        card: 'bogus_card_token'
+        card: stripe_helper.generate_card_token
       )
-    }.to raise_error(Stripe::InvalidRequestError, /integer/i)
+    }.to raise_error(Stripe::InvalidRequestError, /invalid positive integer/i)
   end
 
   it "requires a valid integer amount", :live => true do
@@ -27,9 +27,9 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create(
         amount: 99.0,
         currency: 'usd',
-        card: 'bogus_card_token'
+        card: stripe_helper.generate_card_token
       )
-    }.to raise_error(Stripe::InvalidRequestError, /integer/i)
+    }.to raise_error(Stripe::InvalidRequestError, /invalid integer/i)
   end
 
   it "creates a stripe charge item with a card token" do

--- a/spec/shared_stripe_examples/error_mock_examples.rb
+++ b/spec/shared_stripe_examples/error_mock_examples.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 def expect_card_error(code, param)
-  expect { Stripe::Charge.create() }.to raise_error {|e|
+  expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
     expect(e).to be_a(Stripe::CardError)
     expect(e.http_status).to eq(402)
     expect(e.code).to eq(code)
@@ -33,7 +33,7 @@ shared_examples 'Stripe Error Mocking' do
     error = Stripe::InvalidRequestError.new('Test Invalid', 'param', 987, 'ibody', 'json ibody')
     StripeMock.prepare_error(error)
 
-    expect { Stripe::Charge.create() }.to raise_error {|e|
+    expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
       expect(e).to be_a(Stripe::InvalidRequestError)
       expect(e.param).to eq('param')
       expect(e.message).to eq('Test Invalid')
@@ -64,7 +64,7 @@ shared_examples 'Stripe Error Mocking' do
     custom_error = StandardError.new("Please knock first.")
     StripeMock.prepare_error(custom_error, :new_customer)
 
-    expect { Stripe::Charge.create }.to_not raise_error
+    expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
     expect { Stripe::Customer.create }.to raise_error {|e|
       expect(e).to be_a StandardError
       expect(e.message).to eq("Please knock first.")
@@ -84,12 +84,12 @@ shared_examples 'Stripe Error Mocking' do
   it "only raises a card error when a card charge is attempted" do
     StripeMock.prepare_card_error(:card_declined)
     expect { Stripe::Customer.create(id: 'x') }.to_not raise_error
-    expect { Stripe::Charge.create() }.to raise_error Stripe::CardError
+    expect { Stripe::Charge.create(amount: 1) }.to raise_error Stripe::CardError
   end
 
   it "mocks a card error with a given handler" do
     StripeMock.prepare_card_error(:incorrect_cvc, :new_customer)
-    expect { Stripe::Charge.create() }.to_not raise_error
+    expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
 
     expect { Stripe::Customer.create() }.to raise_error {|e|
       expect(e).to be_a(Stripe::CardError)

--- a/spec/shared_stripe_examples/error_mock_examples.rb
+++ b/spec/shared_stripe_examples/error_mock_examples.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 def expect_card_error(code, param)
-  expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
+  expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error {|e|
     expect(e).to be_a(Stripe::CardError)
     expect(e.http_status).to eq(402)
     expect(e.code).to eq(code)
@@ -33,7 +33,7 @@ shared_examples 'Stripe Error Mocking' do
     error = Stripe::InvalidRequestError.new('Test Invalid', 'param', 987, 'ibody', 'json ibody')
     StripeMock.prepare_error(error)
 
-    expect { Stripe::Charge.create(amount: 1) }.to raise_error {|e|
+    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error {|e|
       expect(e).to be_a(Stripe::InvalidRequestError)
       expect(e.param).to eq('param')
       expect(e.message).to eq('Test Invalid')
@@ -64,7 +64,7 @@ shared_examples 'Stripe Error Mocking' do
     custom_error = StandardError.new("Please knock first.")
     StripeMock.prepare_error(custom_error, :new_customer)
 
-    expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
+    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to_not raise_error
     expect { Stripe::Customer.create }.to raise_error {|e|
       expect(e).to be_a StandardError
       expect(e.message).to eq("Please knock first.")
@@ -84,12 +84,12 @@ shared_examples 'Stripe Error Mocking' do
   it "only raises a card error when a card charge is attempted" do
     StripeMock.prepare_card_error(:card_declined)
     expect { Stripe::Customer.create(id: 'x') }.to_not raise_error
-    expect { Stripe::Charge.create(amount: 1) }.to raise_error Stripe::CardError
+    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error Stripe::CardError
   end
 
   it "mocks a card error with a given handler" do
     StripeMock.prepare_card_error(:incorrect_cvc, :new_customer)
-    expect { Stripe::Charge.create(amount: 1) }.to_not raise_error
+    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to_not raise_error
 
     expect { Stripe::Customer.create() }.to raise_error {|e|
       expect(e).to be_a(Stripe::CardError)


### PR DESCRIPTION
This addresses #71, stripe charges should not allow non-positive-integer amounts:
```
[7] pry »  Stripe::Charge.create(amount: -1, currency: 'usd', customer: stripe_customer_id)
Stripe::InvalidRequestError: Invalid positive integer
from /home/theoretick/.gem/ruby/2.1.2/gems/stripe-1.16.0/lib/stripe.rb:232:in `handle_api_error'
```

Breaking change: I had to change quite a few references with this one since `Stripe::Charge.create` without params was used abundantly elsewhere in the test suite.

Unfortunately, it kills the convenience of easy charge inits but this accurately reflects stripe API usage.

I live-tested these (leading to second commit to clarify slightly different error message), but still had a few unrelated failures i couldn't resolve that did not go away when i reverted changes:

```ruby
$ bundle exec rspec -t live
Running **live** tests against Stripe...
Run options:
  include {:live=>true}
  exclude {:mock_server=>true, :oauth=>true}

StripeMock::Instance
  behaves like Refund API
    creates a stripe refund with the charge ID
    creates a refund off a charge (FAILED - 1)
    handles multiple refunds (FAILED - 2)

Failures:

  1) StripeMock::Instance behaves like Refund API creates a refund off a charge
     Failure/Error: refund = charge.refunds.create(amount: 555)
     NoMethodError:
       undefined method `create' for []:Array
     Shared Example Group: "Refund API" called from ./spec/support/stripe_examples.rb:19
     # ./spec/shared_stripe_examples/refund_examples.rb:63:in `block (2 levels) in <top (required)>'

  2) StripeMock::Instance behaves like Refund API handles multiple refunds
     Failure/Error: refund_1 = charge.refunds.create(amount: 300)
     NoMethodError:
       undefined method `create' for []:Array
     Shared Example Group: "Refund API" called from ./spec/support/stripe_examples.rb:19
     # ./spec/shared_stripe_examples/refund_examples.rb:73:in `block (2 levels) in <top (required)>'

Finished in 6.63 seconds (files took 0.39599 seconds to load)
3 examples, 2 failures

Failed examples:

rspec ./spec/shared_stripe_examples/refund_examples.rb:58 # StripeMock::Instance behaves like Refund API creates a refund off a charge
rspec ./spec/shared_stripe_examples/refund_examples.rb:68 # StripeMock::Instance behaves like Refund API handles multiple refunds
 ```