### PR TITLE
Stripe API update [Breaking change]

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -43,6 +43,7 @@ require 'stripe_mock/request_handlers/validators/param_validators.rb'
 
 require 'stripe_mock/request_handlers/charges.rb'
 require 'stripe_mock/request_handlers/cards.rb'
+require 'stripe_mock/request_handlers/sources.rb'
 require 'stripe_mock/request_handlers/customers.rb'
 require 'stripe_mock/request_handlers/coupons.rb'
 require 'stripe_mock/request_handlers/events.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -364,6 +364,7 @@ module StripeMock
     end
 
     def self.mock_transfer(params={})
+      id = params[:id] || 'tr_test_transfer'
       {
         :status => 'pending',
         :amount => 100,
@@ -376,12 +377,19 @@ module StripeMock
         :recipient => 'test_recipient',
         :fee => 0,
         :fee_details => [],
-        :id => "tr_test_transfer",
+        :id => id,
         :livemode => false,
         :currency => "usd",
         :object => "transfer",
         :date => 1304114826,
         :description => "Transfer description",
+        :reversed => false,
+        :reversals => {
+          :object => "list",
+          :total_count => 0,
+          :has_more => false,
+          :url => "/v1/transfers/#{id}/reversals"
+        },
       }.merge(params)
     end
 

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1,9 +1,9 @@
 module StripeMock
   module Data
 
-    def self.mock_customer(cards, params)
+    def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
-      cards.each {|card| card[:customer] = cus_id}
+      sources.each {|source| source[:customer] = cus_id}
       {
         email: 'stripe_mock@example.com',
         description: 'an auto-generated stripe customer data mock',
@@ -14,11 +14,11 @@ module StripeMock
         delinquent: false,
         discount: nil,
         account_balance: 0,
-        cards: {
+        sources: {
           object: "list",
-          total_count: cards.size,
-          url: "/v1/customers/#{cus_id}/cards",
-          data: cards
+          total_count: sources.size,
+          url: "/v1/customers/#{cus_id}/sources",
+          data: sources
         },
         subscriptions: {
           object: "list",
@@ -26,7 +26,7 @@ module StripeMock
           url: "/v1/customers/#{cus_id}/subscriptions",
           data: []
         },
-        default_card: nil
+        default_source: nil
       }.merge(params)
     end
 
@@ -45,7 +45,7 @@ module StripeMock
         status: 'succeeded',
         fee_details: [
         ],
-        card: {
+        source: {
           object: "card",
           last4: "4242",
           type: "Visa",

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -200,7 +200,7 @@ module StripeMock
         period_start: 1349738950,
         lines: {
           object: "list",
-          count: lines.count,
+          total_count: lines.count,
           url: "/v1/invoices/#{in_id}/lines",
           data: lines
         },

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -42,6 +42,7 @@ module StripeMock
         currency: "usd",
         refunded: false,
         fee: 0,
+        status: 'succeeded',
         fee_details: [
         ],
         card: {

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -20,6 +20,7 @@ module StripeMock
 
     include StripeMock::RequestHandlers::Charges
     include StripeMock::RequestHandlers::Cards
+    include StripeMock::RequestHandlers::Sources
     include StripeMock::RequestHandlers::Subscriptions # must be before Customers
     include StripeMock::RequestHandlers::Customers
     include StripeMock::RequestHandlers::Coupons

--- a/lib/stripe_mock/request_handlers/cards.rb
+++ b/lib/stripe_mock/request_handlers/cards.rb
@@ -3,20 +3,10 @@ module StripeMock
     module Cards
 
       def Cards.included(klass)
-        klass.add_handler 'get /v1/customers/(.*)/cards', :retrieve_cards
-        klass.add_handler 'post /v1/customers/(.*)/cards', :create_card
-        klass.add_handler 'get /v1/customers/(.*)/cards/(.*)', :retrieve_card
-        klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_card
-        klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_card
         klass.add_handler 'get /v1/recipients/(.*)/cards', :retrieve_recipient_cards
         klass.add_handler 'get /v1/recipients/(.*)/cards/(.*)', :retrieve_recipient_card
         klass.add_handler 'post /v1/recipients/(.*)/cards', :create_recipient_card
         klass.add_handler 'delete /v1/recipients/(.*)/cards/(.*)', :delete_recipient_card
-      end
-
-      def create_card(route, method_url, params, headers)
-        route =~ method_url
-        add_card_to(:customer, $1, params, customers)
       end
 
       def create_recipient_card(route, method_url, params, headers)
@@ -24,21 +14,9 @@ module StripeMock
         add_card_to(:recipient, $1, params, recipients)
       end
 
-      def retrieve_cards(route, method_url, params, headers)
-        route =~ method_url
-        retrieve_object_cards(:customer, $1, customers)
-      end
-
       def retrieve_recipient_cards(route, method_url, params, headers)
         route =~ method_url
         retrieve_object_cards(:recipient, $1, recipients)
-      end
-
-      def retrieve_card(route, method_url, params, headers)
-        route =~ method_url
-        customer = assert_existence :customer, $1, customers[$1]
-
-        assert_existence :card, $2, get_card(customer, $2)
       end
 
       def retrieve_recipient_card(route, method_url, params, headers)
@@ -48,25 +26,10 @@ module StripeMock
         assert_existence :card, $2, get_card(recipient, $2, "Recipient")
       end
 
-      def delete_card(route, method_url, params, headers)
-        route =~ method_url
-        delete_card_from(:customer, $1, $2, customers)
-      end
-
       def delete_recipient_card(route, method_url, params, headers)
         route =~ method_url
         delete_card_from(:recipient, $1, $2, recipients)
       end
-
-      def update_card(route, method_url, params, headers)
-        route =~ method_url
-        customer = assert_existence :customer, $1, customers[$1]
-
-        card = assert_existence :card, $2, get_card(customer, $2)
-        card.merge!(params)
-        card
-      end
-
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -14,16 +14,16 @@ module StripeMock
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
 
-        if params[:card] && params[:card].is_a?(String)
+        if params[:source] && params[:source].is_a?(String)
           # if a customer is provided, the card parameter is assumed to be the actual
           # card id, not a token. in this case we'll find the card in the customer
           # object and return that.
           if params[:customer]
-            params[:card] = get_card(customers[params[:customer]], params[:card])
+            params[:source] = get_card(customers[params[:customer]], params[:source])
           else
-            params[:card] = get_card_by_token(params[:card])
+            params[:source] = get_card_by_token(params[:source])
           end
-        elsif params[:card] && params[:card][:id]
+        elsif params[:source] && params[:source][:id]
           raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:card]}", 'card', 400)
         end
 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -12,14 +12,14 @@ module StripeMock
 
       def new_customer(route, method_url, params, headers)
         params[:id] ||= new_id('cus')
-        cards = []
+        sources = []
 
-        if params[:card]
-          cards << get_card_by_token(params.delete(:card))
-          params[:default_card] = cards.first[:id]
+        if params[:source]
+          sources << get_card_by_token(params.delete(:source))
+          params[:default_source] = sources.first[:id]
         end
 
-        customers[ params[:id] ] = Data.mock_customer(cards, params)
+        customers[ params[:id] ] = Data.mock_customer(sources, params)
 
         if params[:plan]
           plan_id = params[:plan].to_s
@@ -44,10 +44,10 @@ module StripeMock
         cus = assert_existence :customer, $1, customers[$1]
         cus.merge!(params)
 
-        if params[:card]
-          new_card = get_card_by_token(params.delete(:card))
+        if params[:source]
+          new_card = get_card_by_token(params.delete(:source))
           add_card_to_object(:customer, new_card, cus, true)
-          cus[:default_card] = new_card[:id]
+          cus[:default_source] = new_card[:id]
         end
 
         cus

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -25,7 +25,7 @@ module StripeMock
           plan_id = params[:plan].to_s
           plan = assert_existence :plan, plan_id, plans[plan_id]
 
-          if params[:default_card].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
+          if params[:default_source].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
             raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
           end
 

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -3,7 +3,8 @@ module StripeMock
     module Helpers
 
       def get_card(object, card_id, class_name='Customer')
-        card = object[:cards][:data].find{|cc| cc[:id] == card_id }
+        cards = object[:cards] || object[:sources]
+        card = cards[:data].find{|cc| cc[:id] == card_id }
         if card.nil?
           msg = "#{class_name} #{object[:id]} does not have card #{card_id}"
           raise Stripe::InvalidRequestError.new(msg, 'card', 404)
@@ -13,23 +14,28 @@ module StripeMock
 
       def add_card_to_object(type, card, object, replace_current=false)
         card[type] = object[:id]
+        cards_or_sources = object[:cards] || object[:sources]
+
+        is_customer = object.has_key?(:sources)
 
         if replace_current
-          object[:cards][:data].delete_if {|card| card[:id] == object[:default_card]}
-          object[:default_card] = card[:id]
+          cards_or_sources[:data].delete_if {|card| card[:id] == object[:default_card]}
+          object[:default_card]   = card[:id] unless is_customer
+          object[:default_source] = card[:id] if is_customer
         else
-          object[:cards][:total_count] += 1
+          cards_or_sources[:total_count] += 1
         end
 
-        object[:default_card] = card[:id] unless object[:default_card]
-        object[:cards][:data] << card
+        object[:default_card]   = card[:id] if !is_customer && object[:default_card].nil?
+        object[:default_source] = card[:id] if is_customer  && object[:default_source].nil?
+        cards_or_sources[:data] << card
 
         card
       end
 
       def retrieve_object_cards(type, type_id, objects)
         resource = assert_existence type, type_id, objects[type_id]
-        cards = resource[:cards]
+        cards = resource[:cards] || resource[:sources]
 
         Data.mock_list_object(cards[:data])
       end
@@ -40,17 +46,22 @@ module StripeMock
         assert_existence :card, card_id, get_card(resource, card_id)
 
         card = { id: card_id, deleted: true }
-        resource[:cards][:data].reject!{|cc|
+        cards_or_sources = resource[:cards] || resource[:sources]
+        cards_or_sources[:data].reject!{|cc|
           cc[:id] == card[:id]
         }
-        resource[:default_card] = resource[:cards][:data].count > 0 ? resource[:cards][:data].first[:id] : nil
+
+        is_customer = object.has_key?(:sources)
+        new_default = cards_or_sources[:data].count > 0 ? cards_or_sources[:data].first[:id] : nil
+        resource[:default_card]   = new_default unless is_customer
+        resource[:default_source] = new_default if is_customer
         card
       end
 
       def add_card_to(type, type_id, params, objects)
         resource = assert_existence type, type_id, objects[type_id]
 
-        card = card_from_params(params[:card])
+        card = card_from_params(params[:card] || params[:source])
         add_card_to_object(type, card, resource)
       end
 
@@ -68,7 +79,6 @@ module StripeMock
         card = get_card_by_token(attrs_or_token)
         validate_card(card)
       end
-
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -51,7 +51,7 @@ module StripeMock
           cc[:id] == card[:id]
         }
 
-        is_customer = object.has_key?(:sources)
+        is_customer = resource.has_key?(:sources)
         new_default = cards_or_sources[:data].count > 0 ? cards_or_sources[:data].first[:id] : nil
         resource[:default_card]   = new_default unless is_customer
         resource[:default_source] = new_default if is_customer

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -2,12 +2,18 @@ module StripeMock
   module RequestHandlers
     module Sources
 
-      def Cards.included(klass)
+      def Sources.included(klass)
         klass.add_handler 'get /v1/customers/(.*)/sources', :retrieve_sources
         klass.add_handler 'post /v1/customers/(.*)/sources', :create_source
         klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
         klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
         klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
+
+        # While Stripe removes these endpoints.
+        # https://github.com/stripe/stripe-ruby/issues/215
+        klass.add_handler 'get /v1/customers/(.*)/cards/(.*)', :retrieve_source
+        klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_source
+        klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_source
       end
 
       def create_source(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -8,12 +8,6 @@ module StripeMock
         klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
         klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
         klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
-
-        # While Stripe removes these endpoints.
-        # https://github.com/stripe/stripe-ruby/issues/215
-        klass.add_handler 'get /v1/customers/(.*)/cards/(.*)', :retrieve_source
-        klass.add_handler 'delete /v1/customers/(.*)/cards/(.*)', :delete_source
-        klass.add_handler 'post /v1/customers/(.*)/cards/(.*)', :update_source
       end
 
       def create_source(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -1,0 +1,46 @@
+module StripeMock
+  module RequestHandlers
+    module Sources
+
+      def Cards.included(klass)
+        klass.add_handler 'get /v1/customers/(.*)/sources', :retrieve_sources
+        klass.add_handler 'post /v1/customers/(.*)/sources', :create_source
+        klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
+        klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
+        klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
+      end
+
+      def create_source(route, method_url, params, headers)
+        route =~ method_url
+        add_card_to(:customer, $1, params, customers)
+      end
+
+      def retrieve_sources(route, method_url, params, headers)
+        route =~ method_url
+        retrieve_object_cards(:customer, $1, customers)
+      end
+
+      def retrieve_source(route, method_url, params, headers)
+        route =~ method_url
+        customer = assert_existence :customer, $1, customers[$1]
+
+        assert_existence :card, $2, get_card(customer, $2)
+      end
+
+      def delete_source(route, method_url, params, headers)
+        route =~ method_url
+        delete_card_from(:customer, $1, $2, customers)
+      end
+
+      def update_source(route, method_url, params, headers)
+        route =~ method_url
+        customer = assert_existence :customer, $1, customers[$1]
+
+        card = assert_existence :card, $2, get_card(customer, $2)
+        card.merge!(params)
+        card
+      end
+
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -17,10 +17,10 @@ module StripeMock
         plan_id = params[:plan]
         plan = assert_existence :plan, plan_id, plans[plan_id]
 
-        if params[:card]
-          new_card = get_card_by_token(params.delete(:card))
+        if params[:source]
+          new_card = get_card_by_token(params.delete(:source))
           add_card_to_object(:customer, new_card, customer)
-          customer[:default_card] = new_card[:id]
+          customer[:default_source] = new_card[:id]
         end
 
         # Ensure customer has card to charge if plan has no trial and is not free
@@ -54,10 +54,10 @@ module StripeMock
         subscription = get_customer_subscription(customer, $2)
         assert_existence :subscription, $2, subscription
 
-        if params[:card]
-          new_card = get_card_by_token(params.delete(:card))
+        if params[:source]
+          new_card = get_card_by_token(params.delete(:source))
           add_card_to_object(:customer, new_card, customer)
-          customer[:default_card] = new_card[:id]
+          customer[:default_source] = new_card[:id]
         end
 
         # expand the plan for addition to the customer object
@@ -111,7 +111,7 @@ module StripeMock
       private
 
       def verify_card_present(customer, plan, params={})
-        if customer[:default_card].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0 && plan[:trial_end].nil? && params[:trial_end].nil?
+        if customer[:default_source].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0 && plan[:trial_end].nil? && params[:trial_end].nil?
           raise Stripe::InvalidRequestError.new('You must supply a valid card xoxo', nil, 400)
         end
       end

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -14,12 +14,12 @@ module StripeMock
 
         cus_id = params[:customer]
 
-        if cus_id && params[:card]
+        if cus_id && params[:source]
           customer = assert_existence :customer, cus_id, customers[cus_id]
 
           # params[:card] is an id; grab it from the db
-          customer_card = get_card(customer, params[:card])
-          assert_existence :card, params[:card], customer_card
+          customer_card = get_card(customer, params[:source])
+          assert_existence :card, params[:source], customer_card
         elsif params[:card]
           # params[:card] is a hash of cc info; "Sanitize" the card number
           params[:card][:fingerprint] = StripeMock::Util.fingerprint(params[:card][:number])
@@ -27,7 +27,7 @@ module StripeMock
           customer_card = params[:card]
         else
           customer = assert_existence :customer, cus_id, customers[cus_id]
-          customer_card = get_card(customer, customer[:default_card])
+          customer_card = get_card(customer, customer[:default_source])
         end
 
         token_id = generate_card_token(customer_card)

--- a/spec/integration_examples/charge_token_examples.rb
+++ b/spec/integration_examples/charge_token_examples.rb
@@ -6,12 +6,12 @@ shared_examples 'Charging with Tokens' do
 
     before do
       @cus = Stripe::Customer.create(
-        :card => stripe_helper.generate_card_token({ :number => '4242424242424242', :brand => 'Visa' })
+        :source => stripe_helper.generate_card_token({ :number => '4242424242424242', :brand => 'Visa' })
       )
 
       @card_token = Stripe::Token.create({
         :customer => @cus.id,
-        :card => @cus.cards.first.id
+        :source => @cus.sources.first.id
       }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
     end
 
@@ -19,20 +19,20 @@ shared_examples 'Charging with Tokens' do
       charge = Stripe::Charge.create({
         :amount => 1099,
         :currency => 'usd',
-        :card => @card_token.id
+        :source => @card_token.id
       }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
 
-      expect(charge.card.id).to_not eq @cus.cards.first.id
-      expect(charge.card.fingerprint).to eq @cus.cards.first.fingerprint
-      expect(charge.card.last4).to eq '4242'
-      expect(charge.card.brand).to eq 'Visa'
+      expect(charge.source.id).to_not eq @cus.sources.first.id
+      expect(charge.source.fingerprint).to eq @cus.sources.first.fingerprint
+      expect(charge.source.last4).to eq '4242'
+      expect(charge.source.brand).to eq 'Visa'
 
       retrieved_charge = Stripe::Charge.retrieve(charge.id)
 
-      expect(retrieved_charge.card.id).to_not eq @cus.cards.first.id
-      expect(retrieved_charge.card.fingerprint).to eq @cus.cards.first.fingerprint
-      expect(retrieved_charge.card.last4).to eq '4242'
-      expect(retrieved_charge.card.brand).to eq 'Visa'
+      expect(retrieved_charge.source.id).to_not eq @cus.sources.first.id
+      expect(retrieved_charge.source.fingerprint).to eq @cus.sources.first.fingerprint
+      expect(retrieved_charge.source.last4).to eq '4242'
+      expect(retrieved_charge.source.brand).to eq 'Visa'
     end
 
     it "throws an error when the card is not an id", :oauth => true do
@@ -40,7 +40,7 @@ shared_examples 'Charging with Tokens' do
         charge = Stripe::Charge.create({
           :amount => 1099,
           :currency => 'usd',
-          :card => @card_token
+          :source => @card_token
         }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
       }.to raise_error(Stripe::InvalidRequestError, /Invalid token id/)
     end

--- a/spec/integration_examples/customer_card_examples.rb
+++ b/spec/integration_examples/customer_card_examples.rb
@@ -5,23 +5,23 @@ shared_examples "Multiple Customer Cards" do
     tok1 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4242424242424242"
     tok2 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4012888888881881"
 
-    cus = Stripe::Customer.create(:email => 'alice@bob.com', :card => tok1.id)
-    default_card = cus.cards.first
-    cus.cards.create(:card => tok2.id)
+    cus = Stripe::Customer.create(:email => 'alice@bob.com', :source => tok1.id)
+    default_card = cus.sources.first
+    cus.sources.create(:source => tok2.id)
 
     cus = Stripe::Customer.retrieve(cus.id)
-    expect(cus.cards.count).to eq(2)
-    expect(cus.default_card).to eq default_card.id
+    expect(cus.sources.count).to eq(2)
+    expect(cus.default_source).to eq default_card.id
   end
 
   it "gives the same two card numbers the same fingerprints", :live => true do
     tok1 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4242424242424242"
     tok2 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4242424242424242"
 
-    cus = Stripe::Customer.create(:email => 'alice@bob.com', :card => tok1.id)
+    cus = Stripe::Customer.create(:email => 'alice@bob.com', :source => tok1.id)
 
     cus = Stripe::Customer.retrieve(cus.id)
-    card = cus.cards.find do |existing_card|
+    card = cus.sources.find do |existing_card|
       existing_card.fingerprint == tok2.card.fingerprint
     end
     expect(card).to_not be_nil
@@ -31,12 +31,12 @@ shared_examples "Multiple Customer Cards" do
     tok1 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4242424242424242"
     tok2 = Stripe::Token.retrieve stripe_helper.generate_card_token :number => "4012888888881881"
 
-    cus = Stripe::Customer.create(:email => 'alice@bob.com', :card => tok1.id)
+    cus = Stripe::Customer.create(:email => 'alice@bob.com', :source => tok1.id)
 
     cus = Stripe::Customer.retrieve(cus.id)
-    card = cus.cards.find do |existing_card|
+    source = cus.sources.find do |existing_card|
       existing_card.fingerprint == tok2.card.fingerprint
     end
-    expect(card).to be_nil
+    expect(source).to be_nil
   end
 end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -64,8 +64,8 @@ describe 'README examples' do
   it "generates a stripe card token" do
     card_token = StripeMock.generate_card_token(last4: "9191", exp_year: 1984)
 
-    cus = Stripe::Customer.create(card: card_token)
-    card = cus.cards.data.first
+    cus = Stripe::Customer.create(source: card_token)
+    card = cus.sources.data.first
     expect(card.last4).to eq("9191")
     expect(card.exp_year).to eq(1984)
   end

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 shared_examples 'Card API' do
 
-  it 'creates/returns a card when using customer.cards.create given a card token' do
+  it 'creates/returns a card when using customer.sources.create given a card token' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-    card = customer.cards.create(card: card_token)
+    card = customer.sources.create(source: card_token)
 
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("1123")
@@ -13,8 +13,8 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(2099)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.cards.count).to eq(1)
-    card = customer.cards.data.first
+    expect(customer.sources.count).to eq(1)
+    card = customer.sources.data.first
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("1123")
     expect(card.exp_month).to eq(11)
@@ -40,9 +40,9 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(2099)
   end
 
-  it 'creates/returns a card when using customer.cards.create given card params' do
+  it 'creates/returns a card when using customer.sources.create given card params' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
-    card = customer.cards.create(card: {
+    card = customer.sources.create(card: {
       number: '4242424242424242',
       exp_month: '11',
       exp_year: '3031',
@@ -55,8 +55,8 @@ shared_examples 'Card API' do
     expect(card.exp_year).to eq(3031)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.cards.count).to eq(1)
-    card = customer.cards.data.first
+    expect(customer.sources.count).to eq(1)
+    card = customer.sources.data.first
     expect(card.customer).to eq('test_customer_sub')
     expect(card.last4).to eq("4242")
     expect(card.exp_month).to eq(11)
@@ -88,88 +88,88 @@ shared_examples 'Card API' do
 
   it "creates a single card with a generated card token", :live => true do
     customer = Stripe::Customer.create
-    expect(customer.cards.count).to eq 0
+    expect(customer.sources.count).to eq 0
 
-    customer.cards.create :card => stripe_helper.generate_card_token
+    customer.sources.create :source => stripe_helper.generate_card_token
     # Yes, stripe-ruby does not actually add the new card to the customer instance
-    expect(customer.cards.count).to eq 0
+    expect(customer.sources.count).to eq 0
 
     customer2 = Stripe::Customer.retrieve(customer.id)
-    expect(customer2.cards.count).to eq 1
-    expect(customer2.default_card).to eq customer2.cards.first.id
+    expect(customer2.sources.count).to eq 1
+    expect(customer2.default_source).to eq customer2.sources.first.id
   end
 
   it 'create does not change the customers default card if already set' do
-    customer = Stripe::Customer.create(id: 'test_customer_sub', default_card: "test_cc_original")
+    customer = Stripe::Customer.create(id: 'test_customer_sub', default_source: "test_cc_original")
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-    card = customer.cards.create(card: card_token)
+    card = customer.sources.create(source: card_token)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.default_card).to eq("test_cc_original")
+    expect(customer.default_source).to eq("test_cc_original")
   end
 
   it 'create updates the customers default card if not set' do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-    card = customer.cards.create(card: card_token)
+    card = customer.sources.create(source: card_token)
 
     customer = Stripe::Customer.retrieve('test_customer_sub')
-    expect(customer.default_card).to_not be_nil
+    expect(customer.default_source).to_not be_nil
   end
 
   describe "retrieval and deletion with customers" do
     let!(:customer) { Stripe::Customer.create(id: 'test_customer_sub') }
     let!(:card_token) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
-    let!(:card) { customer.cards.create(card: card_token) }
+    let!(:card) { customer.sources.create(source: card_token) }
 
     it "can retrieve all customer's cards" do
-      retrieved = customer.cards.all
+      retrieved = customer.sources.all
       expect(retrieved.count).to eq(1)
     end
 
     it "retrieves a customers card" do
-      retrieved = customer.cards.retrieve(card.id)
+      retrieved = customer.sources.retrieve(card.id)
       expect(retrieved.to_s).to eq(card.to_s)
     end
 
     it "retrieves a customer's card after re-fetching the customer" do
-      retrieved = Stripe::Customer.retrieve(customer.id).cards.retrieve(card.id)
+      retrieved = Stripe::Customer.retrieve(customer.id).sources.retrieve(card.id)
       expect(retrieved.id).to eq card.id
     end
 
     it "deletes a customers card" do
       card.delete
       retrieved_cus = Stripe::Customer.retrieve(customer.id)
-      expect(retrieved_cus.cards.data).to be_empty
+      expect(retrieved_cus.sources.data).to be_empty
     end
 
     it "deletes a customers card then set the default_card to nil" do
       card.delete
       retrieved_cus = Stripe::Customer.retrieve(customer.id)
-      expect(retrieved_cus.default_card).to be_nil
+      expect(retrieved_cus.default_source).to be_nil
     end
 
     it "updates the default card if deleted" do
       card.delete
       retrieved_cus = Stripe::Customer.retrieve(customer.id)
-      expect(retrieved_cus.default_card).to be_nil
+      expect(retrieved_cus.default_source).to be_nil
     end
 
     context "deletion when the user has two cards" do
       let!(:card_token_2) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
-      let!(:card_2) { customer.cards.create(card: card_token_2) }
+      let!(:card_2) { customer.sources.create(source: card_token_2) }
 
       it "has just one card anymore" do
         card.delete
         retrieved_cus = Stripe::Customer.retrieve(customer.id)
-        expect(retrieved_cus.cards.data.count).to eq 1
-        expect(retrieved_cus.cards.data.first.id).to eq card_2.id
+        expect(retrieved_cus.sources.data.count).to eq 1
+        expect(retrieved_cus.sources.data.first.id).to eq card_2.id
       end
 
       it "sets the default_card id to the last card remaining id" do
         card.delete
         retrieved_cus = Stripe::Customer.retrieve(customer.id)
-        expect(retrieved_cus.default_card).to eq card_2.id
+        expect(retrieved_cus.default_source).to eq card_2.id
       end
     end
   end
@@ -219,7 +219,7 @@ shared_examples 'Card API' do
     it "throws an error when the customer does not have the retrieving card id" do
       customer = Stripe::Customer.create
       card_id = "card_123"
-      expect { customer.cards.retrieve(card_id) }.to raise_error {|e|
+      expect { customer.sources.retrieve(card_id) }.to raise_error {|e|
         expect(e).to be_a Stripe::InvalidRequestError
         expect(e.message).to include "Customer", customer.id, "does not have", card_id
         expect(e.param).to eq 'card'
@@ -231,7 +231,7 @@ shared_examples 'Card API' do
   context "update card" do
     let!(:customer) { Stripe::Customer.create(id: 'test_customer_sub') }
     let!(:card_token) { stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099) }
-    let!(:card) { customer.cards.create(card: card_token) }
+    let!(:card) { customer.sources.create(source: card_token) }
 
     it "updates the card" do
       exp_month = 10
@@ -241,7 +241,7 @@ shared_examples 'Card API' do
       card.exp_year = exp_year
       card.save
 
-      retrieved = customer.cards.retrieve(card.id)
+      retrieved = customer.sources.retrieve(card.id)
 
       expect(retrieved.exp_month).to eq(exp_month)
       expect(retrieved.exp_year).to eq(exp_year)
@@ -254,13 +254,13 @@ shared_examples 'Card API' do
       customer = Stripe::Customer.create(id: 'test_customer_card')
 
       card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
-      card1 = customer.cards.create(card: card_token)
+      card1 = customer.sources.create(source: card_token)
       card_token = stripe_helper.generate_card_token(last4: "1124", exp_month: 12, exp_year: 2098)
-      card2 = customer.cards.create(card: card_token)
+      card2 = customer.sources.create(source: card_token)
 
       customer = Stripe::Customer.retrieve('test_customer_card')
 
-      list = customer.cards.all
+      list = customer.sources.all
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(2)
@@ -277,7 +277,7 @@ shared_examples 'Card API' do
       Stripe::Customer.create(id: 'no_cards')
       customer = Stripe::Customer.retrieve('no_cards')
 
-      list = customer.cards.all
+      list = customer.sources.all
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(0)

--- a/spec/shared_stripe_examples/card_token_examples.rb
+++ b/spec/shared_stripe_examples/card_token_examples.rb
@@ -7,8 +7,8 @@ shared_examples 'Card Token Mocking' do
     it "generates and reads a card token for create charge" do
       card_token = StripeMock.generate_card_token(last4: "2244", exp_month: 33, exp_year: 2255)
 
-      charge = Stripe::Charge.create(amount: 500, card: card_token)
-      card = charge.card
+      charge = Stripe::Charge.create(amount: 500, source: card_token)
+      card = charge.source
       expect(card.last4).to eq("2244")
       expect(card.exp_month).to eq(33)
       expect(card.exp_year).to eq(2255)
@@ -17,8 +17,8 @@ shared_examples 'Card Token Mocking' do
     it "generates and reads a card token for create customer" do
       card_token = StripeMock.generate_card_token(last4: "9191", exp_month: 99, exp_year: 3005)
 
-      cus = Stripe::Customer.create(card: card_token)
-      card = cus.cards.data.first
+      cus = Stripe::Customer.create(source: card_token)
+      card = cus.sources.data.first
       expect(card.last4).to eq("9191")
       expect(card.exp_month).to eq(99)
       expect(card.exp_year).to eq(3005)
@@ -27,11 +27,11 @@ shared_examples 'Card Token Mocking' do
     it "generates and reads a card token for update customer" do
       card_token = StripeMock.generate_card_token(last4: "1133", exp_month: 11, exp_year: 2099)
 
-      cus = Stripe::Customer.create()
-      cus.card = card_token
+      cus = Stripe::Customer.create
+      cus.source = card_token
       cus.save
 
-      card = cus.cards.data.first
+      card = cus.sources.data.first
       expect(card.last4).to eq("1133")
       expect(card.exp_month).to eq(11)
       expect(card.exp_year).to eq(2099)
@@ -60,8 +60,8 @@ shared_examples 'Card Token Mocking' do
         }
       })
 
-      cus = Stripe::Customer.create(card: card_token.id)
-      card = cus.cards.data.first
+      cus = Stripe::Customer.create(source: card_token.id)
+      card = cus.sources.data.first
       expect(card.last4).to eq("2222")
       expect(card.exp_month).to eq(9)
       expect(card.exp_year).to eq(2017)
@@ -76,11 +76,11 @@ shared_examples 'Card Token Mocking' do
         }
       })
 
-      cus = Stripe::Customer.create()
-      cus.card = card_token.id
+      cus = Stripe::Customer.create
+      cus.source = card_token.id
       cus.save
 
-      card = cus.cards.data.first
+      card = cus.sources.data.first
       expect(card.last4).to eq("4444")
       expect(card.exp_month).to eq(11)
       expect(card.exp_year).to eq(2019)
@@ -96,7 +96,7 @@ shared_examples 'Card Token Mocking' do
       })
 
       cus = Stripe::Customer.create()
-      cus.card = card_token.id
+      cus.source = card_token.id
       cus.save
 
       card_token = Stripe::Token.create({

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -7,7 +7,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create(
         amount: 99,
         currency: 'usd',
-        card: 'bogus_card_token'
+        source: 'bogus_card_token'
       )
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
   end
@@ -16,7 +16,7 @@ shared_examples 'Charge API' do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
 
@@ -31,20 +31,20 @@ shared_examples 'Charge API' do
   it "creates a stripe charge item with a customer and card id" do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: stripe_helper.generate_card_token(number: '4012888888881881'),
+      source: stripe_helper.generate_card_token(number: '4012888888881881'),
       description: "a description"
     })
 
-    expect(customer.cards.data.length).to eq(1)
-    expect(customer.cards.data[0].id).not_to be_nil
-    expect(customer.cards.data[0].last4).to eq('1881')
+    expect(customer.sources.data.length).to eq(1)
+    expect(customer.sources.data[0].id).not_to be_nil
+    expect(customer.sources.data[0].last4).to eq('1881')
 
-    card   = customer.cards.data[0]
+    card   = customer.sources.data[0]
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
       customer: customer.id,
-      card: card.id,
+      source: card.id,
       description: 'a charge with a specific card'
     )
 
@@ -52,7 +52,7 @@ shared_examples 'Charge API' do
     expect(charge.amount).to eq(999)
     expect(charge.description).to eq('a charge with a specific card')
     expect(charge.captured).to eq(true)
-    expect(charge.card.last4).to eq('1881')
+    expect(charge.source.last4).to eq('1881')
   end
 
 
@@ -60,12 +60,12 @@ shared_examples 'Charge API' do
     charge = Stripe::Charge.create({
       amount: 333,
       currency: 'USD',
-      card: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token
     })
     charge2 = Stripe::Charge.create({
       amount: 777,
       currency: 'USD',
-      card: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token
     })
     data = test_data_source(:charges)
     expect(data[charge.id]).to_not be_nil
@@ -79,7 +79,7 @@ shared_examples 'Charge API' do
     original = Stripe::Charge.create({
       amount: 777,
       currency: 'USD',
-      card: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token
     })
     charge = Stripe::Charge.retrieve(original.id)
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -24,6 +24,7 @@ shared_examples 'Charge API' do
     expect(charge.amount).to eq(999)
     expect(charge.description).to eq('card charge')
     expect(charge.captured).to eq(true)
+    expect(charge.status).to eq('succeeded')
   end
 
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -9,19 +9,19 @@ shared_examples 'Customer API' do
   it "creates a stripe customer with a default card" do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: gen_card_tk,
+      source: gen_card_tk,
       description: "a description"
     })
     expect(customer.id).to match(/^test_cus/)
     expect(customer.email).to eq('johnny@appleseed.com')
     expect(customer.description).to eq('a description')
 
-    expect(customer.cards.count).to eq(1)
-    expect(customer.cards.data.length).to eq(1)
-    expect(customer.default_card).to_not be_nil
-    expect(customer.default_card).to eq customer.cards.data.first.id
+    expect(customer.sources.count).to eq(1)
+    expect(customer.sources.data.length).to eq(1)
+    expect(customer.default_source).to_not be_nil
+    expect(customer.default_source).to eq customer.sources.data.first.id
 
-    expect { customer.card }.to raise_error
+    expect { customer.source }.to raise_error
   end
 
   it "creates a stripe customer without a card" do
@@ -33,14 +33,14 @@ shared_examples 'Customer API' do
     expect(customer.email).to eq('cardless@appleseed.com')
     expect(customer.description).to eq('no card')
 
-    expect(customer.cards.count).to eq(0)
-    expect(customer.cards.data.length).to eq(0)
-    expect(customer.default_card).to be_nil
+    expect(customer.sources.count).to eq(0)
+    expect(customer.sources.data.length).to eq(0)
+    expect(customer.default_source).to be_nil
   end
 
   it 'creates a customer with a plan' do
     plan = stripe_helper.create_plan(id: 'silver')
-    customer = Stripe::Customer.create(id: 'test_cus_plan', card: gen_card_tk, :plan => 'silver')
+    customer = Stripe::Customer.create(id: 'test_cus_plan', source: gen_card_tk, :plan => 'silver')
 
     customer = Stripe::Customer.retrieve('test_cus_plan')
     expect(customer.subscriptions.count).to eq(1)
@@ -53,13 +53,13 @@ shared_examples 'Customer API' do
 
   it "creates a customer with a plan (string/symbol agnostic)" do
     plan = stripe_helper.create_plan(id: 'string_id')
-    customer = Stripe::Customer.create(id: 'test_cus_plan', card: gen_card_tk, :plan => :string_id)
+    customer = Stripe::Customer.create(id: 'test_cus_plan', source: gen_card_tk, :plan => :string_id)
 
     customer = Stripe::Customer.retrieve('test_cus_plan')
     expect(customer.subscriptions.first.plan.id).to eq('string_id')
 
     plan = stripe_helper.create_plan(:id => :sym_id)
-    customer = Stripe::Customer.create(id: 'test_cus_plan', card: gen_card_tk, :plan => 'sym_id')
+    customer = Stripe::Customer.create(id: 'test_cus_plan', source: gen_card_tk, :plan => 'sym_id')
 
     customer = Stripe::Customer.retrieve('test_cus_plan')
     expect(customer.subscriptions.first.plan.id).to eq('sym_id')
@@ -70,7 +70,7 @@ shared_examples 'Customer API' do
     it "with a trial when trial_end is set" do
       plan = stripe_helper.create_plan(id: 'no_trial', amount: 999)
       trial_end = Time.now.utc.to_i + 3600
-      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: gen_card_tk, plan: 'no_trial', trial_end: trial_end)
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, plan: 'no_trial', trial_end: trial_end)
 
       customer = Stripe::Customer.retrieve('test_cus_trial_end')
       expect(customer.subscriptions.count).to eq(1)
@@ -86,7 +86,7 @@ shared_examples 'Customer API' do
     it 'overrides trial period length when trial_end is set' do
       plan = stripe_helper.create_plan(id: 'silver', amount: 999, trial_period_days: 14)
       trial_end = Time.now.utc.to_i + 3600
-      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: gen_card_tk, plan: 'silver', trial_end: trial_end)
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, plan: 'silver', trial_end: trial_end)
 
       customer = Stripe::Customer.retrieve('test_cus_trial_end')
       expect(customer.subscriptions.count).to eq(1)
@@ -100,7 +100,7 @@ shared_examples 'Customer API' do
 
     it "returns no trial when trial_end is set to 'now'" do
       plan = stripe_helper.create_plan(id: 'silver', amount: 999, trial_period_days: 14)
-      customer = Stripe::Customer.create(id: 'test_cus_trial_end', card: gen_card_tk, plan: 'silver', trial_end: "now")
+      customer = Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, plan: 'silver', trial_end: "now")
 
       customer = Stripe::Customer.retrieve('test_cus_trial_end')
       expect(customer.subscriptions.count).to eq(1)
@@ -116,7 +116,7 @@ shared_examples 'Customer API' do
     it "returns an error if trial_end is set to a past time" do
       plan = stripe_helper.create_plan(id: 'silver', amount: 999)
       expect {
-        Stripe::Customer.create(id: 'test_cus_trial_end', card: gen_card_tk, plan: 'silver', trial_end: Time.now.utc.to_i - 3600)
+        Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, plan: 'silver', trial_end: Time.now.utc.to_i - 3600)
       }.to raise_error {|e|
         expect(e).to be_a(Stripe::InvalidRequestError)
         expect(e.message).to eq('Invalid timestamp: must be an integer Unix timestamp in the future')
@@ -125,7 +125,7 @@ shared_examples 'Customer API' do
 
     it "returns an error if trial_end is set without a plan" do
       expect {
-        Stripe::Customer.create(id: 'test_cus_trial_end', card: gen_card_tk, trial_end: "now")
+        Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, trial_end: "now")
       }.to raise_error {|e|
         expect(e).to be_a(Stripe::InvalidRequestError)
         expect(e.message).to eq('Received unknown parameter: trial_end')
@@ -136,7 +136,7 @@ shared_examples 'Customer API' do
 
   it 'cannot create a customer with a plan that does not exist' do
     expect {
-      customer = Stripe::Customer.create(id: 'test_cus_no_plan', card: gen_card_tk, :plan => 'non-existant')
+      customer = Stripe::Customer.create(id: 'test_cus_no_plan', source: gen_card_tk, :plan => 'non-existant')
     }.to raise_error {|e|
       expect(e).to be_a(Stripe::InvalidRequestError)
       expect(e.message).to eq('No such plan: non-existant')
@@ -156,11 +156,11 @@ shared_examples 'Customer API' do
   it "stores a created stripe customer in memory" do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: gen_card_tk
+      source: gen_card_tk
     })
     customer2 = Stripe::Customer.create({
       email: 'bob@bobbers.com',
-      card: gen_card_tk
+      source: gen_card_tk
     })
     data = test_data_source(:customers)
     expect(data[customer.id]).to_not be_nil
@@ -173,13 +173,13 @@ shared_examples 'Customer API' do
   it "retrieves a stripe customer" do
     original = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: gen_card_tk
+      source: gen_card_tk
     })
     customer = Stripe::Customer.retrieve(original.id)
 
     expect(customer.id).to eq(original.id)
     expect(customer.email).to eq(original.email)
-    expect(customer.default_card).to eq(original.default_card)
+    expect(customer.default_source).to eq(original.default_source)
     expect(customer.subscriptions.count).to eq(0)
     expect(customer.subscriptions.data).to be_empty
   end
@@ -217,17 +217,17 @@ shared_examples 'Customer API' do
   end
 
   it "updates a stripe customer's card" do
-    original = Stripe::Customer.create(id: 'test_customer_update', card: gen_card_tk)
-    card = original.cards.data.first
-    expect(original.default_card).to eq(card.id)
-    expect(original.cards.count).to eq(1)
+    original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
+    card = original.sources.data.first
+    expect(original.default_source).to eq(card.id)
+    expect(original.sources.count).to eq(1)
 
-    original.card = gen_card_tk
+    original.source = gen_card_tk
     original.save
 
-    new_card = original.cards.data.first
-    expect(original.cards.count).to eq(1)
-    expect(original.default_card).to eq(new_card.id)
+    new_card = original.sources.data.last
+    expect(original.sources.count).to eq(2)
+    expect(original.default_source).to_not eq(card.id)
 
     expect(new_card.id).to_not eq(card.id)
   end

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -92,7 +92,7 @@ shared_examples 'Invoice API' do
 
   context "retrieving upcoming invoice" do
     before do
-      @customer = Stripe::Customer.create(email: 'johnny@appleseed.com', card: stripe_helper.generate_card_token)
+      @customer = Stripe::Customer.create(email: 'johnny@appleseed.com', source: stripe_helper.generate_card_token)
     end
 
     it 'fails without parameters' do

--- a/spec/shared_stripe_examples/transfer_examples.rb
+++ b/spec/shared_stripe_examples/transfer_examples.rb
@@ -10,6 +10,7 @@ shared_examples 'Transfer API' do
     expect(transfer.amount).to eq('100')
     expect(transfer.currency).to eq('usd')
     expect(transfer.recipient).to eq recipient.id
+    expect(transfer.reversed).to eq(false)
   end
 
   describe "listing transfers" do

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 1.15.0'
+  gem.add_dependency 'stripe', '>= 1.20.1'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
This PR will update the Stripe API to the most recent version ([changes here](https://stripe.com/docs/upgrades?since=2015-01-26#whats-changed-since-2015-01-26)).

* This is a breaking change. `Customer`s and `Charge`s will now have `sources` instead of cards.
* This still assumes that all `sources` of a customer are cards, there's no Bitcoin support right now.
* This still has the `customers/cards` endpoints since the Stripe gem has that problem. See stripe/stripe-ruby#215

* No version bump here, I'll leave that to the maintainers.

This fixes #189