### PR TITLE
Require recipient name & type

### DIFF
--- a/lib/stripe_mock/request_handlers/recipients.rb
+++ b/lib/stripe_mock/request_handlers/recipients.rb
@@ -12,6 +12,18 @@ module StripeMock
         params[:id] ||= new_id('rp')
         cards = []
 
+        if params[:name].nil?
+          raise StripeMock::StripeMockError.new("Missing required parameter name for recipients.")
+        end
+
+        if params[:type].nil?
+          raise StripeMock::StripeMockError.new("Missing required parameter type for recipients.")
+        end
+
+        unless %w(individual corporation).include?(params[:type])
+          raise StripeMock::StripeMockError.new("Type must be either individual or corporation..")
+        end
+
         if params[:bank_account]
           params[:active_account] = get_bank_by_token(params.delete(:bank_account))
         end

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -22,7 +22,13 @@ shared_examples 'Card API' do
   end
 
   it 'creates/returns a card when using recipient.cards.create given a card token' do
-    recipient = Stripe::Recipient.create(id: 'test_recipient_sub')
+    params = {
+      id: 'test_recipient_sub',
+      name: 'MyRec',
+      type: 'individual'
+    }
+
+    recipient = Stripe::Recipient.create(params)
     card_token = stripe_helper.generate_card_token(last4: "1123", exp_month: 11, exp_year: 2099)
     card = recipient.cards.create(card: card_token)
 
@@ -64,7 +70,12 @@ shared_examples 'Card API' do
   end
 
   it 'creates/returns a card when using recipient.cards.create given card params' do
-    recipient = Stripe::Recipient.create(id: 'test_recipient_sub')
+    params = {
+      id: 'test_recipient_sub',
+      name: 'MyRec',
+      type: 'individual'
+    }
+    recipient = Stripe::Recipient.create(params)
     card = recipient.cards.create(card: {
       number: '4000056655665556',
       exp_month: '11',

--- a/spec/shared_stripe_examples/recipient_examples.rb
+++ b/spec/shared_stripe_examples/recipient_examples.rb
@@ -28,6 +28,13 @@ shared_examples 'Recipient API' do
     expect { recipient.card }.to raise_error
   end
 
+  it "raises a error if params are invalid" do
+    expect { Stripe::Recipient.create(name: "foo") }.to raise_error
+    expect { Stripe::Recipient.create(type: "individual") }.to raise_error
+    expect { Stripe::Recipient.create(name: "foo", type: "bar") }.to raise_error
+    expect { Stripe::Recipient.create(name: "foo", type: "individual") }.not_to raise_error
+  end
+
   it "creates a stripe recipient without a card" do
     recipient = Stripe::Recipient.create({
       type:  "corporation",
@@ -109,4 +116,3 @@ shared_examples 'Recipient API' do
   end
 
 end
-


### PR DESCRIPTION
- Stripe requires Recipients to have name & type.
- Type should be either `individual` or `corporation`.
