### PR TITLE
fixing for stripe v 1.20.2

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -61,7 +61,11 @@ module StripeMock
         end
 
         # expand the plan for addition to the customer object
-        plan_name = params[:plan] || subscription[:plan][:id]
+        if params[:plan].blank? or params[:plan].nil?
+          plan_name = subscription[:plan][:id]
+        else
+          plan_name = params[:plan]
+        end
         plan = plans[plan_name]
 
         assert_existence :plan, plan_name, plan


### PR DESCRIPTION
With Stripe v 1.20.2  current version of mock does not retrieve plan name correctly.
E.g. if ``params[:plan] == {}`` and `` subscription[:plan][:id] == 'some-plan'``, the result will be ``{}``, but not ``some-plan``