### PR TITLE
Updated default webhook fixtures to use “source” instead of “card”

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/charge.failed.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.failed.json
@@ -14,7 +14,7 @@
       "amount": 1000,
       "currency": "usd",
       "refunded": false,
-      "card": {
+      "source": {
         "id": "cc_00000000000000",
         "object": "card",
         "last4": "4242",

--- a/lib/stripe_mock/webhook_fixtures/charge.refunded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.refunded.json
@@ -14,7 +14,7 @@
       "amount": 1000,
       "currency": "usd",
       "refunded": true,
-      "card": {
+      "source": {
         "id": "cc_00000000000000",
         "object": "card",
         "last4": "4242",

--- a/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
@@ -14,7 +14,7 @@
       "amount": 1000,
       "currency": "usd",
       "refunded": false,
-      "card": {
+      "source": {
         "id": "cc_00000000000000",
         "object": "card",
         "last4": "4242",

--- a/lib/stripe_mock/webhook_fixtures/customer.created.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.created.json
@@ -18,7 +18,7 @@
       "subscription": null,
       "discount": null,
       "account_balance": 0,
-      "cards": {
+      "sources": {
         "object": "list",
         "count": 1,
         "url": "/v1/customers/cus_2I2AhGQOPmEFeu/cards",

--- a/lib/stripe_mock/webhook_fixtures/customer.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.updated.json
@@ -18,7 +18,7 @@
       "subscription": null,
       "discount": null,
       "account_balance": 0,
-      "cards": {
+      "sources": {
         "object": "list",
         "count": 1,
         "url": "/v1/customers/cus_2I2AhGQOPmEFeu/cards",
@@ -48,7 +48,7 @@
           }
         ]
       },
-      "default_card": "cc_2I2akIhmladin5"
+      "default_source": "cc_2I2akIhmladin5"
     },
     "previous_attributes": {
       "description": "Old description"


### PR DESCRIPTION
Based on the 2015-02-18 API changes: https://stripe.com/docs/upgrades#2015-02-18