### PR TITLE
Added support for the card parameter of a token to be a string

### DIFF
--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -20,6 +20,12 @@ module StripeMock
           # params[:card] is an id; grab it from the db
           customer_card = get_card(customer, params[:source])
           assert_existence :card, params[:source], customer_card
+        elsif params[:card].is_a?(String)
+          customer = assert_existence :customer, cus_id, customers[cus_id]
+
+          # params[:card] is an id; grab it from the db
+          customer_card = get_card(customer, params[:card])
+          assert_existence :card, params[:card], customer_card
         elsif params[:card]
           # params[:card] is a hash of cc info; "Sanitize" the card number
           params[:card][:fingerprint] = StripeMock::Util.fingerprint(params[:card][:number])


### PR DESCRIPTION
We upgraded to the latest stripe api version, gem and this mocking library and ran into this problem. We're passing a string id to the card parameter from a previously created card. According to the source code it's expecting this to be in a `source` parameter. However, according to [Stripe's documentation](https://stripe.com/docs/api#create_card_token) the source parameter doesn't exist and we tried using it with source and it simply failed on the live key.

I created a test for how we're using it and added a condition to the code to allow and work with a string card id in addition to the hash.