### PR TITLE
has_more on Stripe::ListObject 

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/transfer.created.json
+++ b/lib/stripe_mock/webhook_fixtures/transfer.created.json
@@ -52,6 +52,7 @@
         "object": "list",
         "count": 1,
         "url": "/v1/transfers/tr_2h8RC13PPvwDZs/transactions",
+        "has_more": false,
         "data": [
           {
             "id": "ch_2fb4RERw49oI8s",

--- a/lib/stripe_mock/webhook_fixtures/transfer.failed.json
+++ b/lib/stripe_mock/webhook_fixtures/transfer.failed.json
@@ -52,6 +52,7 @@
         "object": "list",
         "count": 1,
         "url": "/v1/transfers/tr_2h8RC13PPvwDZs/transactions",
+        "has_more": false,
         "data": [
           {
             "id": "ch_2fb4RERw49oI8s",

--- a/lib/stripe_mock/webhook_fixtures/transfer.paid.json
+++ b/lib/stripe_mock/webhook_fixtures/transfer.paid.json
@@ -52,6 +52,7 @@
         "object": "list",
         "count": 1,
         "url": "/v1/transfers/tr_2h8RC13PPvwDZs/transactions",
+        "has_more": false,
         "data": [
           {
             "id": "ch_2fb4RERw49oI8s",

--- a/lib/stripe_mock/webhook_fixtures/transfer.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/transfer.updated.json
@@ -52,6 +52,7 @@
         "object": "list",
         "count": 1,
         "url": "/v1/transfers/tr_2h8RC13PPvwDZs/transactions",
+        "has_more": false,
         "data": [
           {
             "id": "ch_2fb4RERw49oI8s",


### PR DESCRIPTION
The Stripe::ListObject includes a field `has_more` (see [here](https://stripe.com/docs/api/ruby#create_transfer)). I noticed that these weren't present here.

I've limited my update to the four `transfer.*` fixtures.
