### PR TITLE
Feature/improved warnings

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -86,7 +86,7 @@ module StripeMock
         end
       else
         puts "[StripeMock] Warning : Unrecognized endpoint + method : [#{method} #{url}]"
-        puts "[StripeMock] params: #{params}"
+        puts "[StripeMock] params: #{params}" unless params.empty?
         [{}, api_key]
       end
     end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -85,8 +85,8 @@ module StripeMock
           [res, api_key]
         end
       else
-        puts "WARNING: Unrecognized method + url: [#{method} #{url}]"
-        puts " params: #{params}"
+        puts "[StripeMock] Warning : Unrecognized endpoint + method : [#{method} #{url}]"
+        puts "[StripeMock] params: #{params}"
         [{}, api_key]
       end
     end


### PR DESCRIPTION
It removes the params from logs when there is none and clarify the warning is from this gem.

Before :
![capture d ecran 2015-06-05 a 15 13 17](https://cloud.githubusercontent.com/assets/143380/8013267/f6e13ca4-0b95-11e5-892d-204450874ebc.png)

After :
![capture d ecran 2015-06-05 a 15 16 50](https://cloud.githubusercontent.com/assets/143380/8013269/fe3888cc-0b95-11e5-85ba-933e4b945854.png)
