### PR TITLE
rename card to source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ assign card data to a generated card token:
 it "generates a stripe card token" do
   card_token = StripeMock.generate_card_token(last4: "9191", exp_year: 1984)
 
-  cus = Stripe::Customer.create(card: card_token)
-  card = cus.cards.data.first
+  cus = Stripe::Customer.create(source: card_token)
+  card = cus.sources.data.first
   expect(card.last4).to eq("9191")
   expect(card.exp_year).to eq(1984)
 end


### PR DESCRIPTION
I was new to stripe-ruby-mock.
When I tried to follow this README, I found this problem.
In the beginning, I found that I couldn't retrieve the card which I created for a new customer. I was confused with this, and finally I found this come from README.
I hope it could be helpful for some new guys.

Cheers.