### PR TITLE
Allow Customer creation without card but with trial_end

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -34,7 +34,7 @@ module StripeMock
           plan_id = params[:plan].to_s
           plan = assert_existence :plan, plan_id, plans[plan_id]
 
-          if params[:default_source].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
+          if params[:default_source].nil? && params[:trial_end].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0
             raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
           end
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -116,6 +116,19 @@ shared_examples 'Customer API' do
       expect(customer.subscriptions.first.trial_end).to eq(trial_end)
     end
 
+    it 'creates a customer when trial_end is set and no source', live: true do
+      plan = stripe_helper.create_plan(id: 'silver', amount: 999)
+      trial_end = Time.now.utc.to_i + 3600
+      customer = Stripe::Customer.create(plan: 'silver', trial_end: trial_end)
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.length).to eq(1)
+
+      expect(customer.subscriptions).to_not be_nil
+      expect(customer.subscriptions.first.plan.id).to eq('silver')
+      expect(customer.subscriptions.first.current_period_end).to eq(trial_end)
+      expect(customer.subscriptions.first.trial_end).to eq(trial_end)
+    end
+
     it "returns no trial when trial_end is set to 'now'" do
       plan = stripe_helper.create_plan(id: 'silver', amount: 999, trial_period_days: 14)
       customer = Stripe::Customer.create(id: 'test_cus_trial_end', source: gen_card_tk, plan: 'silver', trial_end: "now")


### PR DESCRIPTION
I've tested it with ```live: true``` flag. It passes.

However I get 10 failures : 

```bash
51 examples, 10 failures, 1 pending

Failed examples:

rspec ./spec/shared_stripe_examples/validation_examples.rb:16 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients runs a luhn check for charges
rspec ./spec/shared_stripe_examples/card_examples.rb:182 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients can retrieve all recipient's cards
rspec ./spec/shared_stripe_examples/card_examples.rb:187 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients deletes a recipient card
rspec ./spec/shared_stripe_examples/card_examples.rb:193 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients deletes a recipient card then set the default_card to nil
rspec ./spec/shared_stripe_examples/card_examples.rb:203 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients deletion when the recipient has two cards has just one card anymore
rspec ./spec/shared_stripe_examples/card_examples.rb:210 # StripeMock::Instance behaves like Card API retrieval and deletion with recipients deletion when the recipient has two cards sets the default_card id to the last card remaining id
rspec ./spec/shared_stripe_examples/charge_examples.rb:227 # StripeMock::Instance behaves like Charge API when use starting_after param
rspec ./spec/shared_stripe_examples/customer_examples.rb:41 # StripeMock::Instance behaves like Customer API creates a stripe customer with a dictionary of card values
rspec ./spec/shared_stripe_examples/recipient_examples.rb:97 # StripeMock::Instance behaves like Recipient API Errors throws an error when the customer does not have the retrieving card id
rspec ./spec/shared_stripe_examples/transfer_examples.rb:67 # StripeMock::Instance behaves like Transfer API when amount is not integer
```

This is not this PR scope but maybe useful.