### PR TITLE
Allow Subscription update without card but with trial_end

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -137,7 +137,8 @@ module StripeMock
       private
 
       def verify_card_present(customer, plan, params={})
-        if customer[:default_source].nil? && plan[:trial_period_days].nil? && plan[:amount] != 0 && plan[:trial_end].nil? && params[:trial_end].nil?
+        if customer[:default_source].nil? && customer[:trial_end].nil? && plan[:trial_period_days].nil? &&
+           plan[:amount] != 0 && plan[:trial_end].nil? && params[:trial_end].nil?
           raise Stripe::InvalidRequestError.new('You must supply a valid card xoxo', nil, 400)
         end
       end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -359,6 +359,17 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.plan.to_hash).to eq(free.to_hash)
     end
 
+    it 'updates a subscription if the customer has a free trial', live: true do
+      stripe_helper.create_plan(id: 'enterprise', amount: 499)
+      trial_end = Time.now.utc.to_i + 3600
+      customer  = Stripe::Customer.create(plan: 'enterprise',
+                                          trial_end: trial_end)
+      subscription          = customer.subscriptions.first
+      subscription.quantity = 2
+      subscription.save
+      expect(subscription.quantity).to eq(2)
+    end
+
     it "updates a customer with no card to a plan with a free trial" do
       free = stripe_helper.create_plan(id: 'free', amount: 0)
       trial = stripe_helper.create_plan(id: 'trial', amount: 999, trial_period_days: 14)


### PR DESCRIPTION
Hi !
A quick addition to permit a Subscription's update in trial.