### PR TITLE
Fix test errors on charges and oauth

### DIFF
--- a/spec/integration_examples/charge_token_examples.rb
+++ b/spec/integration_examples/charge_token_examples.rb
@@ -2,45 +2,47 @@ require 'spec_helper'
 
 shared_examples 'Charging with Tokens' do
 
-  describe "With OAuth" do
+  describe "With OAuth", :oauth => true do
 
-    before do
-      @cus = Stripe::Customer.create(
+    let(:cus) do
+      Stripe::Customer.create(
         :source => stripe_helper.generate_card_token({ :number => '4242424242424242', :brand => 'Visa' })
       )
+    end
 
-      @card_token = Stripe::Token.create({
-        :customer => @cus.id,
-        :source => @cus.sources.first.id
+    let(:card_token) do
+      Stripe::Token.create({
+        :customer => cus.id,
+        :source => cus.sources.first.id
       }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
     end
 
-    it "creates with an oauth access token", :oauth => true do
+    it "creates with an oauth access token" do
       charge = Stripe::Charge.create({
         :amount => 1099,
         :currency => 'usd',
-        :source => @card_token.id
+        :source => card_token.id
       }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
 
-      expect(charge.source.id).to_not eq @cus.sources.first.id
-      expect(charge.source.fingerprint).to eq @cus.sources.first.fingerprint
+      expect(charge.source.id).to_not eq cus.sources.first.id
+      expect(charge.source.fingerprint).to eq cus.sources.first.fingerprint
       expect(charge.source.last4).to eq '4242'
       expect(charge.source.brand).to eq 'Visa'
 
       retrieved_charge = Stripe::Charge.retrieve(charge.id)
 
-      expect(retrieved_charge.source.id).to_not eq @cus.sources.first.id
-      expect(retrieved_charge.source.fingerprint).to eq @cus.sources.first.fingerprint
+      expect(retrieved_charge.source.id).to_not eq cus.sources.first.id
+      expect(retrieved_charge.source.fingerprint).to eq cus.sources.first.fingerprint
       expect(retrieved_charge.source.last4).to eq '4242'
       expect(retrieved_charge.source.brand).to eq 'Visa'
     end
 
-    it "throws an error when the card is not an id", :oauth => true do
+    it "throws an error when the card is not an id" do
       expect {
         charge = Stripe::Charge.create({
           :amount => 1099,
           :currency => 'usd',
-          :source => @card_token
+          :source => card_token
         }, ENV['STRIPE_TEST_OAUTH_ACCESS_TOKEN'])
       }.to raise_error(Stripe::InvalidRequestError, /Invalid token id/)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,10 @@ RSpec.configure do |c|
     end
     c.after(:each) { sleep 1 }
   else
+    c.filter_run_excluding :oauth => true
     Stripe.api_key ||= ''
   end
+
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
 end

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '= 1.21.0'
+  gem.add_dependency 'stripe', '>= 1.21.0'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
- Workaround for unwanted params that Stripe sends even when they aren't
modified un Update Charge call.
- Fix oauth tests being run even when the oauth => true isn't set.
- Use let instead of instance variable in oauth tests.
- Allow tests to be focused to debug.
- fix #215 

There are two things that are in this PR but are not strictly related to the bugfixes. The `filter_run focus` and the refactor of the `charge_token` to use `let` instead of instance variables.

If you want, I can split those in separate PR.