### PR TITLE
Delete empty params before merge to prevent overwrite

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -58,6 +58,10 @@ module StripeMock
       def update_customer(route, method_url, params, headers)
         route =~ method_url
         cus = assert_existence :customer, $1, customers[$1]
+
+        # Delete those params if their value is nil. Workaround of the problematic way Stripe serialize objects
+        params.delete(:sources) if params[:sources] && params[:sources][:data].nil?
+        params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
         cus.merge!(params)
 
         if params[:source]

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -271,6 +271,16 @@ shared_examples 'Customer API' do
     expect(customer.discount.coupon).to be_a Stripe::Coupon
   end
 
+  it "retrieves the customer's default source after it was updated" do
+    customer = Stripe::Customer.create()
+    customer.source = gen_card_tk
+    customer.save
+    card = customer.sources.retrieve(customer.default_source)
+
+    expect(customer.sources).to be_a(Stripe::ListObject)
+    expect(card).to be_a(Stripe::Card)
+  end
+
   it "updates a stripe customer's card" do
     original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
     card = original.sources.data.first


### PR DESCRIPTION
Without deleting, the params would overwrite the `sources` list, wich would lose it's `object: 'list'` key and would be converted to a normal `Stripe::Object` instead of a `Stripe::ListObject`