### PR TITLE
Add a method for deauthorizing accounts

### DIFF
--- a/lib/stripe_mock/request_handlers/accounts.rb
+++ b/lib/stripe_mock/request_handlers/accounts.rb
@@ -8,6 +8,7 @@ module StripeMock
         klass.add_handler 'get /v1/accounts/(.*)',  :get_account
         klass.add_handler 'post /v1/accounts/(.*)', :update_account
         klass.add_handler 'get /v1/accounts',       :list_accounts
+        klass.add_handler 'post /oauth/deauthorize',:deauthorize
       end
 
       def new_account(route, method_url, params, headers)
@@ -29,6 +30,11 @@ module StripeMock
 
       def list_accounts(route, method_url, params, headers)
         Data.mock_list_object(accounts.values, params)
+      end
+
+      def deauthorize(route, method_url, params, headers)
+        route =~ method_url
+        Stripe::StripeObject.construct_from(:stripe_user_id => params[:stripe_user_id])
       end
     end
   end

--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -14,4 +14,12 @@ shared_examples 'Account API' do
     expect(accounts).to be_a Stripe::ListObject
     expect(accounts.data).to eq []
   end
+
+  it 'deauthorizes the stripe account', live: true do
+    account = Stripe::Account.retrieve
+    result = account.deauthorize('CLIENT_ID')
+
+    expect(result).to be_a Stripe::StripeObject
+    expect(result[:stripe_user_id]).to eq account[:id]
+  end
 end


### PR DESCRIPTION
This request adds a handler for the `Account#deauthorize` endpoint. I needed to test this endpoint in my app, which is using Stripe Connect.

Note: Technically the deauthorize method hits `/oauth/` instead of `/v1/accounts`, so I could see an argument for moving this code into another module. On the other hand, the official Stripe gem actually lumps this functionality into the `Account` class with the other account related api calls. So I chose to follow Stripe's example and do the same.