### PR TITLE
Update customer source from hash

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -72,7 +72,7 @@ module StripeMock
           unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
             raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
           end
-          new_card = card_from_params(params.delete[:source])
+          new_card = card_from_params(params.delete(:source))
           add_card_to_object(:customer, new_card, cus, true)
           cus[:default_source] = new_card[:id]
         end

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -64,8 +64,15 @@ module StripeMock
         params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
         cus.merge!(params)
 
-        if params[:source]
+        if params[:source] && params[:source].is_a?(String)
           new_card = get_card_by_token(params.delete(:source))
+          add_card_to_object(:customer, new_card, cus, true)
+          cus[:default_source] = new_card[:id]
+        elsif  params[:source] && params[:source].is_a?(Hash)
+          unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
+            raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
+          end
+          new_card = card_from_params(params.delete[:source])
           add_card_to_object(:customer, new_card, cus, true)
           cus[:default_source] = new_card[:id]
         end

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -64,15 +64,15 @@ module StripeMock
         params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
         cus.merge!(params)
 
-        if params[:source] && params[:source].is_a?(String)
-          new_card = get_card_by_token(params.delete(:source))
-          add_card_to_object(:customer, new_card, cus, true)
-          cus[:default_source] = new_card[:id]
-        elsif  params[:source] && params[:source].is_a?(Hash)
-          unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
-            raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
+        if params[:source] 
+          if params[:source].is_a?(String)
+            new_card = get_card_by_token(params.delete(:source))
+          elsif params[:source].is_a?(Hash)
+            unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
+              raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)
+            end
+            new_card = card_from_params(params.delete(:source))
           end
-          new_card = card_from_params(params.delete(:source))
           add_card_to_object(:customer, new_card, cus, true)
           cus[:default_source] = new_card[:id]
         end

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -15,7 +15,7 @@ module StripeMock
       def generate_card_token(card_params={})
         card_data = { :number => "4242424242424242", :exp_month => 9, :exp_year => 2018, :cvc => "999" }
         card = StripeMock::Util.card_merge(card_data, card_params)
-        card[:fingerprint] = StripeMock::Util.fingerprint(card[:number])
+        card[:fingerprint] = StripeMock::Util.fingerprint(card[:number]) if StripeMock.state == 'local'
 
         stripe_token = Stripe::Token.create(:card => card)
         stripe_token.id

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -281,7 +281,7 @@ shared_examples 'Customer API' do
     expect(card).to be_a(Stripe::Card)
   end
 
-  it "updates a stripe customer's card" do
+  it "updates a stripe customer's card from a token" do
     original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
     card = original.sources.data.first
     expect(original.default_source).to eq(card.id)
@@ -295,6 +295,26 @@ shared_examples 'Customer API' do
     expect(original.default_source).to_not eq(card.id)
 
     expect(new_card.id).to_not eq(card.id)
+  end
+
+  it "updates a stripe customer's card from a hash" do
+    original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
+    card = original.sources.data.first
+    expect(original.default_source).to eq(card.id)
+    expect(original.sources.data.count).to eq(1)
+
+    original.source = {
+      object: 'card',
+      number: '4012888888881881',
+      exp_year: DateTime.now.next_year.to_s,
+      exp_month: '12'
+    }
+
+    original.save
+
+    new_card = original.sources.data.last
+    expect(original.sources.data.count).to eq(1)
+    expect(original.default_source).to_not eq(card.id)
   end
 
   it "deletes a customer" do

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -282,7 +282,7 @@ shared_examples 'Customer API' do
   end
 
   it "updates a stripe customer's card from a token" do
-    original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
+    original = Stripe::Customer.create( source: gen_card_tk)
     card = original.sources.data.first
     expect(original.default_source).to eq(card.id)
     expect(original.sources.data.count).to eq(1)
@@ -298,7 +298,7 @@ shared_examples 'Customer API' do
   end
 
   it "updates a stripe customer's card from a hash" do
-    original = Stripe::Customer.create(id: 'test_customer_update', source: gen_card_tk)
+    original = Stripe::Customer.create( source: gen_card_tk)
     card = original.sources.data.first
     expect(original.default_source).to eq(card.id)
     expect(original.sources.data.count).to eq(1)
@@ -306,8 +306,9 @@ shared_examples 'Customer API' do
     original.source = {
       object: 'card',
       number: '4012888888881881',
-      exp_year: DateTime.now.next_year.to_s,
-      exp_month: '12'
+      exp_year: 2018,
+      exp_month: 12,
+      cvc: 666
     }
 
     original.save


### PR DESCRIPTION
Add the ability to use a hash to update a customer's default source, and spec to prove behavior