### PR TITLE
Prevent metadata being lost on charge update

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -44,7 +44,7 @@ module StripeMock
           raise Stripe::InvalidRequestError.new("Received unknown parameters: #{disallowed.join(', ')}" , '', 400)
         end
 
-        charges[id] = charge.merge(params)
+        charges[id] = Util.rmerge(charge, params)
       end
 
       def get_charges(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -156,6 +156,22 @@ shared_examples 'Charge API' do
     expect(updated.fraud_details.to_hash).to eq(charge.fraud_details.to_hash)
   end
 
+  it "does not loose data when updating a charge" do
+    original = Stripe::Charge.create({
+      amount: 777,
+      currency: 'USD',
+      source: stripe_helper.generate_card_token,
+      metadata: {:foo => "bar"}
+    })
+    original.metadata[:receipt_id] = 1234
+    original.save
+
+    updated = Stripe::Charge.retrieve(original.id)
+
+    expect(updated.metadata[:foo]).to eq "bar"
+    expect(updated.metadata[:receipt_id]).to eq 1234
+  end
+
   it "disallows most parameters on updating a stripe charge" do
     original = Stripe::Charge.create({
       amount: 777,

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -156,7 +156,7 @@ shared_examples 'Charge API' do
     expect(updated.fraud_details.to_hash).to eq(charge.fraud_details.to_hash)
   end
 
-  it "does not loose data when updating a charge" do
+  it "does not lose data when updating a charge" do
     original = Stripe::Charge.create({
       amount: 777,
       currency: 'USD',


### PR DESCRIPTION
Currently, updating metadata on a charge causes existing metadata (and some other stored data, such as refunds) to be lost.

This appears to be because we call `merge`, while really we should be recursively merging the existing charge hash with the new parameters.

This PR updates the `update_charge` method to use `rmerge`, and adds a simple test case.