### PR TITLE
Charge requires either source or customer to be set

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -14,6 +14,9 @@ module StripeMock
 
       def new_charge(route, method_url, params, headers)
         id = new_id('ch')
+        if !params[:source] && !params[:customer]
+          raise Stripe::InvalidRequestError.new("Must provide source or customer.", 'card', 400)
+        end
 
         if params[:source] && params[:source].is_a?(String)
           # if a customer is provided, the card parameter is assumed to be the actual

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -21,6 +21,16 @@ shared_examples 'Charge API' do
     }.to raise_error(Stripe::InvalidRequestError, /missing required param: amount/i)
   end
 
+  it "requires either a source or a customer token" do
+    expect {
+      Stripe::Charge.create(
+        amount: 999,
+        currency: 'USD',
+        description: 'card charge'
+      )
+    }.to raise_error {Stripe::InvalidRequestError, "Must provide source or customer."}
+  end
+
   it "requires presence of currency", :live => true do
     expect {
       charge = Stripe::Charge.create(


### PR DESCRIPTION
As per the Stripe docs, [creating a new charge](https://stripe.com/docs/api/ruby#create_charge) requires either a customer token or a source to be set:
![screen shot 2015-12-01 at 5 43 40 pm](https://cloud.githubusercontent.com/assets/1047986/11516734/2c408a86-9853-11e5-99f4-c12cf454ac31.png)
