### PR TITLE
Fix for saving a customer invalidating sources

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -62,6 +62,10 @@ module StripeMock
         # Delete those params if their value is nil. Workaround of the problematic way Stripe serialize objects
         params.delete(:sources) if params[:sources] && params[:sources][:data].nil?
         params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
+        if params[:sources] && !params[:sources][:data].nil?
+          # Copy old sources over empty objects
+          params[:sources][:data].collect!.with_index {|v, i| v.keys.length == 0 ? cus[:sources][:data][i].clone : v }
+        end
         cus.merge!(params)
 
         if params[:source] 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -64,7 +64,11 @@ module StripeMock
         params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
         if params[:sources] && !params[:sources][:data].nil?
           # Copy old sources over empty objects
-          params[:sources][:data].collect!.with_index {|v, i| v.keys.length == 0 ? cus[:sources][:data][i].clone : v }
+          params[:sources][:data].collect!.with_index {|v, i| !v[:type] ? cus[:sources][:data][i].clone : v }
+        end
+        if params[:subscriptions] && !params[:subscriptions][:data].nil?
+          # Copy old subscriptions over empty objects
+          params[:subscriptions][:data].collect!.with_index {|v, i| !v[:type] ? cus[:subscriptions][:data][i].clone : v }
         end
         cus.merge!(params)
 

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -62,13 +62,12 @@ module StripeMock
         # Delete those params if their value is nil. Workaround of the problematic way Stripe serialize objects
         params.delete(:sources) if params[:sources] && params[:sources][:data].nil?
         params.delete(:subscriptions) if params[:subscriptions] && params[:subscriptions][:data].nil?
+        # Delete those params if their values aren't valid. Workaround of the problematic way Stripe serialize objects
         if params[:sources] && !params[:sources][:data].nil?
-          # Copy old sources over empty objects
-          params[:sources][:data].collect!.with_index {|v, i| !v[:type] ? cus[:sources][:data][i].clone : v }
+          params.delete(:sources) unless params[:sources][:data].any?{ |v| !!v[:type]}
         end
         if params[:subscriptions] && !params[:subscriptions][:data].nil?
-          # Copy old subscriptions over empty objects
-          params[:subscriptions][:data].collect!.with_index {|v, i| !v[:type] ? cus[:subscriptions][:data][i].clone : v }
+          params.delete(:subscriptions) unless params[:subscriptions][:data].any?{ |v| !!v[:type]}
         end
         cus.merge!(params)
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -318,6 +318,16 @@ shared_examples 'Customer API' do
     expect(original.default_source).to_not eq(card.id)
   end
 
+  it "still has sources after save when sources unchanged" do
+    original = Stripe::Customer.create(source: gen_card_tk)
+    card = original.sources.data.first
+    card_id = card.id
+
+    original.save
+
+    expect(original.sources.data.first.id).to eq(card_id)
+  end
+
   it "deletes a customer" do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     customer = customer.delete

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -322,10 +322,12 @@ shared_examples 'Customer API' do
     original = Stripe::Customer.create(source: gen_card_tk)
     card = original.sources.data.first
     card_id = card.id
+    expect(original.sources.total_count).to eq(1)
 
     original.save
 
     expect(original.sources.data.first.id).to eq(card_id)
+    expect(original.sources.total_count).to eq(1)
   end
 
   it "still has subscriptions after save when subscriptions unchanged" do
@@ -333,10 +335,12 @@ shared_examples 'Customer API' do
     original = Stripe::Customer.create(source: gen_card_tk, plan: 'silver')
     subscription = original.subscriptions.data.first
     subscription_id = subscription.id
+    expect(original.subscriptions.total_count).to eq(1)
 
     original.save
 
     expect(original.subscriptions.data.first.id).to eq(subscription_id)
+    expect(original.subscriptions.total_count).to eq(1)
   end
 
   it "deletes a customer" do

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -328,6 +328,17 @@ shared_examples 'Customer API' do
     expect(original.sources.data.first.id).to eq(card_id)
   end
 
+  it "still has subscriptions after save when subscriptions unchanged" do
+    plan = stripe_helper.create_plan(id: 'silver')
+    original = Stripe::Customer.create(source: gen_card_tk, plan: 'silver')
+    subscription = original.subscriptions.data.first
+    subscription_id = subscription.id
+
+    original.save
+
+    expect(original.subscriptions.data.first.id).to eq(subscription_id)
+  end
+
   it "deletes a customer" do
     customer = Stripe::Customer.create(id: 'test_customer_sub')
     customer = customer.delete


### PR DESCRIPTION
If you have a customer who has a source on the server, you pull it down, and then you call save, the Stripe Ruby gem sends up `sources: [{}]` where I'm guessing the `{}` is a placeholder to say "don't change this source" (seems a bit weird to me - surely at least including an id would be a good idea?). I think it has something to do with [these lines from the stripe ruby gem](https://github.com/stripe/stripe-ruby/blob/4e01b13efcc6557ca0f78d20e93f4b7c617d94a3/lib/stripe/stripe_object.rb#L146-L148). Or maybe something else is going on... I don't know.

Anyway, when we wanted to just update a `metadata` key on the customer, this was replacing the cards with empty hashes and that meant even doing `card.id` started throwing errors. This patch fixes it by just copying the old data with the relevant index from the previous data in the case of empty hashes.

Let me know if you'd like me to make any tweaks, this is my first Ruby pull request so very happy to receive guidance!