### PR TITLE
create a charge object when adding a subscription to a customer

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -26,6 +26,8 @@ module StripeMock
       end
 
       def add_subscription_to_customer(cus, sub)
+        id = new_id('ch')
+        charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount])
         cus[:subscriptions][:total_count] = (cus[:subscriptions][:total_count] || 0) + 1
         cus[:subscriptions][:data].unshift sub
       end
@@ -41,14 +43,14 @@ module StripeMock
       # `intervals` is set to 2 when calculating Stripe::Invoice.upcoming end from current_period_start & plan
       def get_ending_time(start_time, plan, intervals = 1)
         case plan[:interval]
-          when "week"
-            start_time + (604800 * (plan[:interval_count] || 1) * intervals)
-          when "month"
-            (Time.at(start_time).to_datetime >> ((plan[:interval_count] || 1) * intervals)).to_time.to_i
-          when "year"
-            (Time.at(start_time).to_datetime >> (12 * intervals)).to_time.to_i # max period is 1 year
-          else
-            start_time
+        when "week"
+          start_time + (604800 * (plan[:interval_count] || 1) * intervals)
+        when "month"
+          (Time.at(start_time).to_datetime >> ((plan[:interval_count] || 1) * intervals)).to_time.to_i
+        when "year"
+          (Time.at(start_time).to_datetime >> (12 * intervals)).to_time.to_i # max period is 1 year
+        else
+          start_time
         end
       end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -25,6 +25,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data).to_not be_empty
       expect(customer.subscriptions.count).to eq(1)
       expect(customer.subscriptions.data.length).to eq(1)
+      expect(customer.charges.data.length).to eq(1)
 
       expect(customer.subscriptions.data.first.id).to eq(sub.id)
       expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
@@ -32,6 +33,17 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
       expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
 
+    end
+    
+    it 'creates a charge for the customer', live: true do
+      stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999)
+
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      customer.subscriptions.create({ :plan => 'silver', :metadata => { :foo => "bar", :example => "yes" } })
+      customer = Stripe::Customer.retrieve(customer.id)
+
+      expect(customer.charges.data.length).to eq(1)
+      expect(customer.charges.data.first.amount).to eq(4999)
     end
 
     it 'contains coupon object', live: true do


### PR DESCRIPTION
Added a charge object to customers when creating a subscription. This is the way stripe responds when you create a subscription.