### PR TITLE
Hotfix: return correct error code after kill_server

### DIFF
--- a/lib/stripe_mock/api/server.rb
+++ b/lib/stripe_mock/api/server.rb
@@ -21,7 +21,14 @@ module StripeMock
       ){
         StripeMock::Server.start_new(opts)
       }
-      at_exit { kill_server(pid_path) }
+      at_exit {
+        begin
+          e = $! # last exception
+          kill_server(pid_path)
+        ensure
+          raise e if $! != e
+        end
+      }
     end
 
     def kill_server(pid_path=nil)


### PR DESCRIPTION
I realised that even when my cucumber tests where failing cucumber was still returning an exit code 0.  
I wondered why and I found the culprit. This at_exit block in the stripe mock server is a problem because it overwrites the exit code of cucumber.
This PR fixes this.