### PR TITLE
Add `incorrect_zip` error type

### DIFF
--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -34,7 +34,8 @@ module StripeMock
         card_declined: add_json_body(["The card was declined", nil, 'card_declined', 402]),
         missing: add_json_body(["There is no card on a customer that is being charged.", nil, 'missing', 402]),
         processing_error: add_json_body(["An error occurred while processing the card", nil, 'processing_error', 402]),
-        card_error: add_json_body(['This card number looks invalid.', 'number', 'invalid_number', 402])
+        card_error: add_json_body(['This card number looks invalid.', 'number', 'invalid_number', 402]),
+        incorrect_zip: add_json_body(["The zip code you supplied failed validation.", "address_zip", "incorrect_zip", 402]),
       }
     end
 

--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -31,11 +31,11 @@ module StripeMock
         invalid_cvc: add_json_body(["The card's security code is invalid", 'cvc', 'invalid_cvc', 402]),
         expired_card: add_json_body(["The card has expired", 'exp_month', 'expired_card', 402]),
         incorrect_cvc: add_json_body(["The card's security code is incorrect", 'cvc', 'incorrect_cvc', 402]),
+        incorrect_zip: add_json_body(["The zip code you supplied failed validation.", "address_zip", "incorrect_zip", 402]),
         card_declined: add_json_body(["The card was declined", nil, 'card_declined', 402]),
         missing: add_json_body(["There is no card on a customer that is being charged.", nil, 'missing', 402]),
         processing_error: add_json_body(["An error occurred while processing the card", nil, 'processing_error', 402]),
         card_error: add_json_body(['This card number looks invalid.', 'number', 'invalid_number', 402]),
-        incorrect_zip: add_json_body(["The zip code you supplied failed validation.", "address_zip", "incorrect_zip", 402]),
       }
     end
 


### PR DESCRIPTION
Adds the error for `address_zip` validation failure:

```ruby
=> #<Stripe::CardError: (Status 402) (Request req_7n9NQecAm2O9rL) The zip code you supplied failed validation.>
[5] pry(main)> e.cause
=> 402 Payment Required: {
  "error": {
    "message": "The zip code you supplied failed validation.",
    "type": "card_error",
    "param": "address_zip",
    "code": "incorrect_zip",
    "charge": "ch_17XZ4UHSPBoWO95qiSRGtb3D"
  }
}
```