### PR TITLE
Feature/stripe api version 1.34.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This gem has unexpectedly grown in popularity and I've gotten pretty busy, so I'
 
 In your gemfile:
 
-    gem 'stripe-ruby-mock', '~> 2.2.1', :require => 'stripe_mock'
+    gem 'stripe-ruby-mock', '~> 2.3.1', :require => 'stripe_mock'
 
 ## Features
 
@@ -23,7 +23,7 @@ In your gemfile:
 
 ### Specifications
 
-**STRIPE API TARGET VERSION:** 2015-09-08 (master)
+**STRIPE API TARGET VERSION:** 1.34.0 (2016-01-25)
 
 Older API version branches:
 
@@ -62,7 +62,7 @@ describe MyApp do
     # Specify :source in place of :card (with same value) to return customer with source data
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token
     })
     expect(customer.email).to eq('johnny@appleseed.com')
   end

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "2.2.1"
+  VERSION = "2.3.1"
 end

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '1.31.0'
+  gem.add_dependency 'stripe', '1.34.0'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
This MR:

1. Updates version of **stripe** gem to the latest, i.e. 1.34.0 (25 Jan 2016).
2. Updates version of **stripe-ruby-mock** itself from 2.2.1 to 2.3.1
3. Fixes sample in README that shows deprecated API creating Customer.