### PR TITLE
Added support for / fixed a bug with `charge.mark_as_safe`

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -142,6 +142,8 @@ module StripeMock
            params[:refunds].has_key?(:data) && params[:refunds][:data].nil?)
           allowed << :refunds
         end
+
+        allowed
       end
     end
   end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -156,6 +156,20 @@ shared_examples 'Charge API' do
     expect(updated.fraud_details.to_hash).to eq(charge.fraud_details.to_hash)
   end
 
+  it "marks a charge as safe" do
+    original = Stripe::Charge.create({
+      amount: 777,
+      currency: 'USD',
+      source: stripe_helper.generate_card_token
+    })
+    charge = Stripe::Charge.retrieve(original.id)
+
+    charge.mark_as_safe
+
+    updated = Stripe::Charge.retrieve(original.id)
+    expect(updated.fraud_details[:user_report]).to eq "safe"
+  end
+
   it "does not lose data when updating a charge" do
     original = Stripe::Charge.create({
       amount: 777,


### PR DESCRIPTION
Previously, calling `charge.mark_as_safe` would blow up [here](https://github.com/charitywater/stripe-ruby-mock/blob/eaf7f5f30b92f32dc40ef47d67cff2ac093536ae/lib/stripe_mock/request_handlers/charges.rb#L42) because `allowed_params` was returning `nil`.