### PR TITLE
Allow webhooks for Stripe Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ it "mocks a stripe webhook" do
   expect(customer_object.default_card).to_not be_nil
   # etc.
 end
+
+it "mocks stripe connect webhooks" do
+  event = StripeMock.mock_webhook_event('customer.created', user_id: 'acc_123123')
+
+  expect(event.user_id).to eq('acc_123123')
+end
 ```
 
 ### Customizing Webhooks

--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -15,6 +15,7 @@ module StripeMock
 
     json = Stripe::Util.symbolize_names(json)
     params = Stripe::Util.symbolize_names(params)
+    json[:user_id] = params.delete(:user_id) if params.key?(:user_id)
     json[:data][:object] = Util.rmerge(json[:data][:object], params)
     json.delete(:id)
 

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -70,6 +70,12 @@ shared_examples 'Webhook Events API' do
     expect(data[event_b.id][:id]).to eq(event_b.id)
   end
 
+  it "handles stripe connect event when user_id is present" do
+  	acc_12314 = 'acc_12314'
+    event = StripeMock.mock_webhook_event('customer.created', user_id: acc_12314)
+    expect(event[:user_id]).to eq(acc_12314)
+  end
+
   it "retrieves an eveng using the event resource" do
     webhook_event = StripeMock.mock_webhook_event('plan.created')
     expect(webhook_event.id).to_not be_nil
@@ -145,9 +151,9 @@ shared_examples 'Webhook Events API' do
       invoice_item_created_event = StripeMock.mock_webhook_event('invoiceitem.created')
       expect(invoice_item_created_event).to be_a(Stripe::Event)
       expect(invoice_item_created_event).to_not be_nil
-      
+
       events = Stripe::Event.all
-      
+
       expect(events.count).to eq(5)
       expect(events.map &:id).to include(customer_created_event.id, plan_created_event.id, coupon_created_event.id, invoice_created_event.id, invoice_item_created_event.id)
       expect(events.map &:type).to include('customer.created', 'plan.created', 'coupon.created', 'invoice.created', 'invoiceitem.created')
@@ -173,13 +179,13 @@ shared_examples 'Webhook Events API' do
       invoice_item_created_event = StripeMock.mock_webhook_event('invoiceitem.created')
       expect(invoice_item_created_event).to be_a(Stripe::Event)
       expect(invoice_item_created_event).to_not be_nil
-      
+
       events = Stripe::Event.all(limit: 3)
-      
+
       expect(events.count).to eq(3)
       expect(events.map &:id).to include(customer_created_event.id, plan_created_event.id, coupon_created_event.id)
       expect(events.map &:type).to include('customer.created', 'plan.created', 'coupon.created')
-    end 
+    end
 
   end
 


### PR DESCRIPTION
Stripe uses the user_id parameter when the webhook if for Connect. This commit extracts user_id from the passed in params and sets it at the root level of the json. This should be safe enough as there is no other use of user_id in the stripe api.