### PR TITLE
Update stripe-ruby-mock.gemspec

### DIFF
--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>=1.31.0'
+  gem.add_dependency 'stripe', '>= 1.31.0'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Missing space was causing the match to be exactly version 1.31.0 of stripe gem.  Added space to make it match >= 1.31.0