### PR TITLE
Avoid to require an api key to get the instance working

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -4,6 +4,8 @@ module StripeMock
     include StripeMock::RequestHandlers::Helpers
     include StripeMock::RequestHandlers::ParamValidators
 
+    DUMMY_API_KEY = (0...32).map { (65 + rand(26)).chr }.join.downcase
+
     # Handlers are ordered by priority
     @@handlers = []
 
@@ -71,7 +73,7 @@ module StripeMock
     def mock_request(method, url, api_key, params={}, headers={}, api_base_url=nil)
       return {} if method == :xtest
 
-      api_key ||= Stripe.api_key
+      api_key ||= (Stripe.api_key || DUMMY_API_KEY)
 
       # Ensure params hash has symbols as keys
       params = Stripe::Util.symbolize_names(params)


### PR DESCRIPTION
related to this issue #209 

It seems pointless to me to need to add a api_key that it's not being used for almost all ( at least the functions that i need) the functions from the stripe instance so this will be a patch for this, you can still set up the api key if you want but if you don't you are good to go w/ the dummy