### PR TITLE
Implement basic support for bank account sources

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -34,6 +34,7 @@ require 'stripe_mock/api/live'
 require 'stripe_mock/api/test_helpers'
 require 'stripe_mock/api/webhooks'
 
+require 'stripe_mock/request_handlers/helpers/bank_account_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/card_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/charge_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/coupon_helpers.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -235,9 +235,13 @@ module StripeMock
         object: "bank_account",
         bank_name: "STRIPEMOCK TEST BANK",
         last4: "6789",
+        routing_number: '110000000',
         country: "US",
         currency: "usd",
         validated: false,
+        status: 'new',
+        account_holder_name: 'John Doe',
+        account_holder_type: 'individual',
         fingerprint: "aBcFinGerPrINt123"
       }.merge(params)
     end
@@ -487,7 +491,7 @@ module StripeMock
       }
     end
 
-    def self.mock_token(params={})
+    def self.mock_card_token(params={})
       {
         :id => 'tok_default',
         :livemode => false,
@@ -513,6 +517,22 @@ module StripeMock
           :address_state => nil,
           :address_zip => nil,
           :address_country => nil
+        }
+      }.merge(params)
+    end
+
+    def self.mock_bank_account_token(params={})
+      {
+        :id => 'tok_default',
+        :livemode => false,
+        :used => false,
+        :object => 'token',
+        :type => 'bank_account',
+        :bank_account => {
+          :id => 'bank_account_default',
+          :object => 'bank_account',
+          :last4 => '2222',
+          :fingerprint => 'JRRLXGh38NiYygM7',
         }
       }.merge(params)
     end

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -22,7 +22,7 @@ module StripeMock
               end
               card_from_params(params[:source])
             else
-              get_card_by_token(params.delete(:source))
+              get_card_or_bank_by_token(params.delete(:source))
             end
           sources << new_card
           params[:default_source] = sources.first[:id]
@@ -71,9 +71,9 @@ module StripeMock
         end
         cus.merge!(params)
 
-        if params[:source] 
+        if params[:source]
           if params[:source].is_a?(String)
-            new_card = get_card_by_token(params.delete(:source))
+            new_card = get_card_or_bank_by_token(params.delete(:source))
           elsif params[:source].is_a?(Hash)
             unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
               raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)

--- a/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
@@ -1,0 +1,14 @@
+module StripeMock
+  module RequestHandlers
+    module Helpers
+
+      def verify_bank_account(object, bank_account_id, class_name='Customer')
+        bank_accounts = object[:bank_accounts] || object[:sources]
+        bank_account = bank_accounts[:data].find{|acc| acc[:id] == bank_account_id }
+        return if bank_account.nil?
+        bank_account['status'] = 'verified'
+        bank_account
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -4,6 +4,7 @@ module StripeMock
 
       def generate_bank_token(bank_params)
         token = new_id 'btok'
+        bank_params[:id] = new_id 'bank_account'
         @bank_tokens[token] = Data.mock_bank_account bank_params
         token
       end
@@ -31,6 +32,10 @@ module StripeMock
         else
           @card_tokens.delete(token)
         end
+      end
+
+      def get_card_or_bank_by_token(token)
+        @card_tokens[token] || @bank_tokens[token] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token}", 'tok', 404))
       end
 
     end

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -5,6 +5,7 @@ module StripeMock
       def Sources.included(klass)
         klass.add_handler 'get /v1/customers/(.*)/sources', :retrieve_sources
         klass.add_handler 'post /v1/customers/(.*)/sources', :create_source
+        klass.add_handler 'post /v1/customers/(.*)/sources/(.*)/verify', :verify_source
         klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
         klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
         klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
@@ -39,6 +40,14 @@ module StripeMock
         card = assert_existence :card, $2, get_card(customer, $2)
         card.merge!(params)
         card
+      end
+
+      def verify_source(route, method_url, params, headers)
+        route =~ method_url
+        customer = assert_existence :customer, $1, customers[$1]
+
+        bank_account = assert_existence :bank_account, $2, verify_bank_account(customer, $2)
+        bank_account
       end
 
     end

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -39,7 +39,7 @@ module StripeMock
         token_id = generate_card_token(customer_card)
         card = @card_tokens[token_id]
 
-        Data.mock_token(params.merge :id => token_id, :card => card)
+        Data.mock_card_token(params.merge :id => token_id, :card => card)
       end
 
       def get_token(route, method_url, params, headers)
@@ -49,9 +49,9 @@ module StripeMock
         assert_existence :token, $1, bank_or_card
 
         if bank_or_card[:object] == 'card'
-          Data.mock_token(:id => $1, :card => bank_or_card)
+          Data.mock_card_token(:id => $1, :card => bank_or_card)
         elsif bank_or_card[:object] == 'bank_account'
-          Data.mock_token(:id => $1, :bank_account => bank_or_card)
+          Data.mock_bank_account_token(:id => $1, :bank_account => bank_or_card)
         end
       end
     end


### PR DESCRIPTION
This allows creating a customer using bank account tokens, defaulting to "new" state, and then always marking as verified when verify endpoint gets called.

---

Note that this was the minimum change necessary in order to make our feature specs work - I'm sure one could cover the API more extensively, but this is the minimum so we can use this library for mocking.

