### PR TITLE
Begins adding Balance Transaction API mocking

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -44,6 +44,7 @@ require 'stripe_mock/request_handlers/helpers/token_helpers.rb'
 require 'stripe_mock/request_handlers/validators/param_validators.rb'
 
 require 'stripe_mock/request_handlers/accounts.rb'
+require 'stripe_mock/request_handlers/balance_transactions.rb'
 require 'stripe_mock/request_handlers/charges.rb'
 require 'stripe_mock/request_handlers/cards.rb'
 require 'stripe_mock/request_handlers/sources.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -695,9 +695,53 @@ module StripeMock
       }
     end
 
-    def self.mock_list_object(data, params = {})
+    def self.mock_list_object(data, params={})
       list = StripeMock::Data::List.new(data, params)
       list.to_h
     end
+
+    def self.mock_balance_transactions(ids=[])
+      bts = {}
+      ids.each do |id|
+        bts[id] = self.mock_balance_transaction(id: id)
+      end
+      bts
+    end
+
+    def self.mock_balance_transaction(params = {})
+      bt_id = params[:id] || 'test_txn_default'
+      source = params[:source] || 'ch_test_charge'
+      {
+        id: bt_id,
+        object: "balance_transaction",
+        amount: 10000,
+        available_on: 1462406400,
+        created: 1461880226,
+        currency: "usd",
+        description: nil,
+        fee: 320,
+        fee_details: [
+          {
+            amount: 320,
+            application: nil,
+            currency: "usd",
+            description: "Stripe processing fees",
+            type: "stripe_fee"
+          }
+        ],
+        net: 9680,
+        source: "#{source}",
+        sourced_transfers: {
+          object: "list",
+          data: [],
+          has_more: false,
+          total_count: 0,
+          url: "/v1/transfers?source_transaction=#{source}"
+        },
+        status: "pending",
+        type: "charge"
+      }.merge(params)
+    end
+
   end
 end

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -730,7 +730,7 @@ module StripeMock
           }
         ],
         net: 9680,
-        source: "#{source}",
+        source: source,
         sourced_transfers: {
           object: "list",
           data: [],

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -21,6 +21,7 @@ module StripeMock
     end
 
     include StripeMock::RequestHandlers::Accounts
+    include StripeMock::RequestHandlers::BalanceTransactions
     include StripeMock::RequestHandlers::Charges
     include StripeMock::RequestHandlers::Cards
     include StripeMock::RequestHandlers::Sources
@@ -38,14 +39,15 @@ module StripeMock
     include StripeMock::RequestHandlers::Tokens
 
 
-    attr_reader :accounts, :bank_tokens, :charges, :coupons, :customers, :disputes, :events,
-                :invoices, :invoice_items, :orders, :plans, :recipients, :transfers,
-                :subscriptions
+    attr_reader :accounts, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
+                :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
+                :transfers, :subscriptions
 
     attr_accessor :error_queue, :debug
 
     def initialize
       @accounts = {}
+      @balance_transactions = Data.mock_balance_transactions(['txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI'])
       @bank_tokens = {}
       @card_tokens = {}
       @customers = {}

--- a/lib/stripe_mock/request_handlers/balance_transactions.rb
+++ b/lib/stripe_mock/request_handlers/balance_transactions.rb
@@ -1,0 +1,21 @@
+module StripeMock
+  module RequestHandlers
+    module BalanceTransactions
+
+      def BalanceTransactions.included(klass)
+        klass.add_handler 'get /v1/balance/history/(.*)',  :get_balance_transaction
+        klass.add_handler 'get /v1/balance/history',       :list_balance_transactions
+      end
+
+      def get_balance_transaction(route, method_url, params, headers)
+        route =~ method_url
+        assert_existence :balance_transaction, $1, balance_transactions[$1]
+      end
+
+      def list_balance_transactions(route, method_url, params, headers)
+        Data.mock_list_object(balance_transactions.values, params)
+      end
+
+    end
+  end
+end

--- a/spec/shared_stripe_examples/balance_transaction_examples.rb
+++ b/spec/shared_stripe_examples/balance_transaction_examples.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+shared_examples 'Balance Transaction API' do
+
+  it "returns an error if balance transaction does not exist" do
+    txn_id = 'txn_xxxxxxxxxxxxxxxxxxxxxxxx'
+
+    expect {
+      Stripe::BalanceTransaction.retrieve(txn_id)
+    }.to raise_error { |e|
+      expect(e).to be_a(Stripe::InvalidRequestError)
+      expect(e.message).to eq('No such balance_transaction: ' + txn_id)
+    }
+  end
+
+  it "retrieves a single balance transaction" do
+    txn_id = 'txn_05RsQX2eZvKYlo2C0FRTGSSA'
+    txn = Stripe::BalanceTransaction.retrieve(txn_id)
+
+    expect(txn).to be_a(Stripe::BalanceTransaction)
+    expect(txn.id).to eq(txn_id)
+  end
+
+  describe "listing balance transactions" do
+
+    it "retrieves all balance transactions" do
+      disputes = Stripe::BalanceTransaction.all
+
+      expect(disputes.count).to eq(10)
+      expect(disputes.map &:id).to include('txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI')
+    end
+
+  end
+
+end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -348,4 +348,5 @@ shared_examples 'Customer API' do
     customer = customer.delete
     expect(customer.deleted).to eq(true)
   end
+
 end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -348,5 +348,4 @@ shared_examples 'Customer API' do
     customer = customer.delete
     expect(customer.deleted).to eq(true)
   end
-
 end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -4,15 +4,16 @@ def require_stripe_examples
   Dir["./spec/integration_examples/**/*.rb"].each {|f| require f}
 end
 
-def it_behaves_like_stripe(&block) 
+def it_behaves_like_stripe(&block)
   it_behaves_like 'Account API', &block
+  it_behaves_like 'Balance Transaction API', &block
   it_behaves_like 'Bank Account Token Mocking', &block
   it_behaves_like 'Card Token Mocking', &block
   it_behaves_like 'Card API', &block
   it_behaves_like 'Charge API', &block
   it_behaves_like 'Coupon API', &block
-  it_behaves_like 'Customer API', &block 
-  it_behaves_like 'Dispute API', &block  
+  it_behaves_like 'Customer API', &block
+  it_behaves_like 'Dispute API', &block
   it_behaves_like 'Extra Features', &block
   it_behaves_like 'Invoice API', &block
   it_behaves_like 'Invoice Item API', &block


### PR DESCRIPTION
This isn't ready to pull yet (I don't think), but I'd like to start a conversation/review if anyone can tell me if I'm heading in the right direction here. BalanceTransaction API only includes a list and get operation, so that's all that's covered. There's also a Balance API that I could potentially add to this.