### PR TITLE
Master Blaster: Fix commits lost by force push, lock Stripe to < 1.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This gem has unexpectedly grown in popularity and I've gotten pretty busy, so I'
 
 In your gemfile:
 
-    gem 'stripe-ruby-mock', '~> 2.2.2', :require => 'stripe_mock'
+    gem 'stripe-ruby-mock', '~> 2.2.3', :require => 'stripe_mock'
 
 ## Features
 

--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -34,6 +34,7 @@ require 'stripe_mock/api/live'
 require 'stripe_mock/api/test_helpers'
 require 'stripe_mock/api/webhooks'
 
+require 'stripe_mock/request_handlers/helpers/bank_account_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/card_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/charge_helpers.rb'
 require 'stripe_mock/request_handlers/helpers/coupon_helpers.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -235,9 +235,13 @@ module StripeMock
         object: "bank_account",
         bank_name: "STRIPEMOCK TEST BANK",
         last4: "6789",
+        routing_number: '110000000',
         country: "US",
         currency: "usd",
         validated: false,
+        status: 'new',
+        account_holder_name: 'John Doe',
+        account_holder_type: 'individual',
         fingerprint: "aBcFinGerPrINt123"
       }.merge(params)
     end
@@ -487,7 +491,7 @@ module StripeMock
       }
     end
 
-    def self.mock_token(params={})
+    def self.mock_card_token(params={})
       {
         :id => 'tok_default',
         :livemode => false,
@@ -513,6 +517,22 @@ module StripeMock
           :address_state => nil,
           :address_zip => nil,
           :address_country => nil
+        }
+      }.merge(params)
+    end
+
+    def self.mock_bank_account_token(params={})
+      {
+        :id => 'tok_default',
+        :livemode => false,
+        :used => false,
+        :object => 'token',
+        :type => 'bank_account',
+        :bank_account => {
+          :id => 'bank_account_default',
+          :object => 'bank_account',
+          :last4 => '2222',
+          :fingerprint => 'JRRLXGh38NiYygM7',
         }
       }.merge(params)
     end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -4,6 +4,8 @@ module StripeMock
     include StripeMock::RequestHandlers::Helpers
     include StripeMock::RequestHandlers::ParamValidators
 
+    DUMMY_API_KEY = (0...32).map { (65 + rand(26)).chr }.join.downcase
+
     # Handlers are ordered by priority
     @@handlers = []
 
@@ -71,7 +73,7 @@ module StripeMock
     def mock_request(method, url, api_key, params={}, headers={}, api_base_url=nil)
       return {} if method == :xtest
 
-      api_key ||= Stripe.api_key
+      api_key ||= (Stripe.api_key || DUMMY_API_KEY)
 
       # Ensure params hash has symbols as keys
       params = Stripe::Util.symbolize_names(params)

--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -22,7 +22,7 @@ module StripeMock
               end
               card_from_params(params[:source])
             else
-              get_card_by_token(params.delete(:source))
+              get_card_or_bank_by_token(params.delete(:source))
             end
           sources << new_card
           params[:default_source] = sources.first[:id]
@@ -71,9 +71,9 @@ module StripeMock
         end
         cus.merge!(params)
 
-        if params[:source] 
+        if params[:source]
           if params[:source].is_a?(String)
-            new_card = get_card_by_token(params.delete(:source))
+            new_card = get_card_or_bank_by_token(params.delete(:source))
           elsif params[:source].is_a?(Hash)
             unless params[:source][:object] && params[:source][:number] && params[:source][:exp_month] && params[:source][:exp_year]
               raise Stripe::InvalidRequestError.new('You must supply a valid card', nil, 400)

--- a/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/bank_account_helpers.rb
@@ -1,0 +1,14 @@
+module StripeMock
+  module RequestHandlers
+    module Helpers
+
+      def verify_bank_account(object, bank_account_id, class_name='Customer')
+        bank_accounts = object[:bank_accounts] || object[:sources]
+        bank_account = bank_accounts[:data].find{|acc| acc[:id] == bank_account_id }
+        return if bank_account.nil?
+        bank_account['status'] = 'verified'
+        bank_account
+      end
+    end
+  end
+end

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -4,6 +4,7 @@ module StripeMock
 
       def generate_bank_token(bank_params)
         token = new_id 'btok'
+        bank_params[:id] = new_id 'bank_account'
         @bank_tokens[token] = Data.mock_bank_account bank_params
         token
       end
@@ -31,6 +32,10 @@ module StripeMock
         else
           @card_tokens.delete(token)
         end
+      end
+
+      def get_card_or_bank_by_token(token)
+        @card_tokens[token] || @bank_tokens[token] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token}", 'tok', 404))
       end
 
     end

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -5,6 +5,7 @@ module StripeMock
       def Sources.included(klass)
         klass.add_handler 'get /v1/customers/(.*)/sources', :retrieve_sources
         klass.add_handler 'post /v1/customers/(.*)/sources', :create_source
+        klass.add_handler 'post /v1/customers/(.*)/sources/(.*)/verify', :verify_source
         klass.add_handler 'get /v1/customers/(.*)/sources/(.*)', :retrieve_source
         klass.add_handler 'delete /v1/customers/(.*)/sources/(.*)', :delete_source
         klass.add_handler 'post /v1/customers/(.*)/sources/(.*)', :update_source
@@ -39,6 +40,14 @@ module StripeMock
         card = assert_existence :card, $2, get_card(customer, $2)
         card.merge!(params)
         card
+      end
+
+      def verify_source(route, method_url, params, headers)
+        route =~ method_url
+        customer = assert_existence :customer, $1, customers[$1]
+
+        bank_account = assert_existence :bank_account, $2, verify_bank_account(customer, $2)
+        bank_account
       end
 
     end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -14,7 +14,7 @@ module StripeMock
         route =~ method_url
         customer = assert_existence :customer, $1, customers[$1]
 
-        plan_id = params[:plan]
+        plan_id = params[:plan].to_s
         plan = assert_existence :plan, plan_id, plans[plan_id]
 
         if params[:source]

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -39,7 +39,7 @@ module StripeMock
         token_id = generate_card_token(customer_card)
         card = @card_tokens[token_id]
 
-        Data.mock_token(params.merge :id => token_id, :card => card)
+        Data.mock_card_token(params.merge :id => token_id, :card => card)
       end
 
       def get_token(route, method_url, params, headers)
@@ -49,9 +49,9 @@ module StripeMock
         assert_existence :token, $1, bank_or_card
 
         if bank_or_card[:object] == 'card'
-          Data.mock_token(:id => $1, :card => bank_or_card)
+          Data.mock_card_token(:id => $1, :card => bank_or_card)
         elsif bank_or_card[:object] == 'bank_account'
-          Data.mock_token(:id => $1, :bank_account => bank_or_card)
+          Data.mock_bank_account_token(:id => $1, :bank_account => bank_or_card)
         end
       end
     end

--- a/lib/stripe_mock/version.rb
+++ b/lib/stripe_mock/version.rb
@@ -1,4 +1,4 @@
 module StripeMock
   # stripe-ruby-mock version
-  VERSION = "2.2.2"
+  VERSION = "2.2.3"
 end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -35,6 +35,23 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
+    it "adds a new subscription to customer (string/symbol agnostic)" do
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      expect(customer.subscriptions.count).to eq(0)
+
+      plan = stripe_helper.create_plan(id: :silver, name: 'Silver Plan', amount: 4999, currency: 'usd')
+      sub = customer.subscriptions.create({ :plan => 'silver' })
+      customer = Stripe::Customer.retrieve(customer.id)
+      expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.count).to eq(1)
+
+      plan = stripe_helper.create_plan(id: 'gold', name: 'Gold Plan', amount: 14999, currency: 'usd')
+      sub = customer.subscriptions.create({ :plan => :gold })
+      customer = Stripe::Customer.retrieve(customer.id)
+      expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(customer.subscriptions.count).to eq(2)
+    end
+
     it 'creates a charge for the customer', live: true do
       stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999)
 
@@ -267,6 +284,7 @@ shared_examples 'Customer Subscriptions' do
         expect(e.message).to eq("Invalid timestamp: can be no more than five years in the future")
       }
     end
+
   end
 
   context "updating a subscription" do

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 1.31.0'
+  gem.add_dependency 'stripe', ['>= 1.31.0', '< 1.42']
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>=1.31.0'
+  gem.add_dependency 'stripe', '>= 1.31.0'
   gem.add_dependency 'jimson-temp'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
* Reintroduces master commits deleted by force push.
* Locks Stripe to < 1.42 to avoid failing tests with new subscriptions API introduced in 1.42 (https://github.com/stripe/stripe-ruby/blob/master/History.txt).

See https://github.com/rebelidealist/stripe-ruby-mock/pull/326 for the rabbit hole I went down with this one.