### PR TITLE
Add status and receipt_number to refund response

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -192,7 +192,9 @@ module StripeMock
         object: "refund",
         balance_transaction: "txn_4fWh2RKvgxcXqV",
         metadata: {},
-        charge: "ch_4fWhYjzQ23UFWT"
+        charge: "ch_4fWhYjzQ23UFWT",
+        receipt_number: nil,
+        status: "succeeded"
       }.merge(params)
     end
 

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -43,6 +43,19 @@ shared_examples 'Refund API' do
     expect(refund.refunds.data.first.id).to match(/^test_re/)
   end
 
+  it "creates a stripe refund with a status" do
+    charge = Stripe::Charge.create(
+      amount: 999,
+      currency: 'USD',
+      card: stripe_helper.generate_card_token,
+      description: 'card charge'
+    )
+    refund = charge.refund
+
+    expect(refund.refunds.data.count).to eq 1
+    expect(refund.refunds.data.first.status).to eq("succeeded")
+  end
+  
   it "creates a stripe refund with a different balance transaction than the charge" do
     charge = Stripe::Charge.create(
       amount: 999,


### PR DESCRIPTION
I ran into some trouble when I was using stripe-ruby-mock and expecting a `Stripe::Refund` object to have a `status` field, so I just added it.

Based on the Stripe documentation: https://stripe.com/docs/api/ruby#refund_object  the refund object should have those fields.