### PR TITLE
Support generate_bank_token in stripe_helper

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -17,6 +17,23 @@ module StripeMock
         card
       end
 
+      def add_source_to_object(type, source, object, replace_current=false)
+        source[type] = object[:id]
+        sources = object[:sources]
+
+        if replace_current && sources[:data]
+          sources[:data].delete_if {|source| source[:id] == object[:default_source]}
+          object[:default_source] = source[:id]
+          sources[:data] = [source]
+        else
+          sources[:total_count] = (sources[:total_count] || 0) + 1
+          (sources[:data] ||= []) << source
+        end
+        object[:default_source] = source[:id] if object[:default_source].nil?
+
+        source
+      end
+
       def add_card_to_object(type, card, object, replace_current=false)
         card[type] = object[:id]
         cards_or_sources = object[:cards] || object[:sources]
@@ -62,6 +79,24 @@ module StripeMock
         resource[:default_card]   = new_default unless is_customer
         resource[:default_source] = new_default if is_customer
         card
+      end
+
+      def add_source_to(type, type_id, params, objects)
+        resource = assert_existence type, type_id, objects[type_id]
+
+        source =
+          if params[:card]
+            card_from_params(params[:card])
+          elsif params[:bank_account]
+            get_bank_by_token(params[:bank_account])
+          else
+            begin
+              get_card_by_token(params[:source])
+            rescue Stripe::InvalidRequestError
+              get_bank_by_token(params[:source])
+            end
+          end
+        add_source_to_object(type, source, resource)
       end
 
       def add_card_to(type, type_id, params, objects)

--- a/lib/stripe_mock/request_handlers/sources.rb
+++ b/lib/stripe_mock/request_handlers/sources.rb
@@ -13,7 +13,7 @@ module StripeMock
 
       def create_source(route, method_url, params, headers)
         route =~ method_url
-        add_card_to(:customer, $1, params, customers)
+        add_source_to(:customer, $1, params, customers)
       end
 
       def retrieve_sources(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/tokens.rb
+++ b/lib/stripe_mock/request_handlers/tokens.rb
@@ -8,7 +8,7 @@ module StripeMock
       end
 
       def create_token(route, method_url, params, headers)
-        if params[:customer].nil? && params[:card].nil?
+        if params[:customer].nil? && params[:card].nil? && params[:bank_account].nil?
           raise Stripe::InvalidRequestError.new('You must supply either a card, customer, or bank account to create a token.', nil, 400)
         end
 
@@ -31,15 +31,25 @@ module StripeMock
           params[:card][:fingerprint] = StripeMock::Util.fingerprint(params[:card][:number])
           params[:card][:last4] = params[:card][:number][-4,4]
           customer_card = params[:card]
+        elsif params[:bank_account]
+          # params[:card] is a hash of cc info; "Sanitize" the card number
+          bank_account = params[:bank_account]
         else
           customer = assert_existence :customer, cus_id, customers[cus_id]
           customer_card = get_card(customer, customer[:default_source])
         end
 
-        token_id = generate_card_token(customer_card)
-        card = @card_tokens[token_id]
+        if bank_account
+          token_id = generate_bank_token(bank_account)
+          bank_account = @bank_tokens[token_id]
 
-        Data.mock_card_token(params.merge :id => token_id, :card => card)
+          Data.mock_bank_account_token(params.merge :id => token_id, :bank_account => bank_account)
+        else
+          token_id = generate_card_token(customer_card)
+          card = @card_tokens[token_id]
+
+          Data.mock_card_token(params.merge :id => token_id, :card => card)
+        end
       end
 
       def get_token(route, method_url, params, headers)

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -21,6 +21,21 @@ module StripeMock
         stripe_token.id
       end
 
+      def generate_bank_token(bank_account_params={})
+        bank_account = {
+          :country => "US",
+          :currency => "usd",
+          :account_holder_name => "Jane Austen",
+          :account_holder_type => "individual",
+          :routing_number => "110000000",
+          :account_number => "000123456789"
+        }.merge(bank_account_params)
+        bank_account[:fingerprint] = StripeMock::Util.fingerprint(bank_account[:account_number]) if StripeMock.state == 'local'
+
+        stripe_token = Stripe::Token.create(:bank_account => bank_account)
+        stripe_token.id
+      end
+
       def create_coupon_params(params = {})
         {
           id: '10BUCKS',

--- a/spec/shared_stripe_examples/bank_examples.rb
+++ b/spec/shared_stripe_examples/bank_examples.rb
@@ -1,0 +1,202 @@
+require 'spec_helper'
+
+shared_examples 'Bank API' do
+
+  it 'creates/returns a bank when using customer.sources.create given a bank token' do
+    customer = Stripe::Customer.create(id: 'test_customer_sub')
+    bank_token = stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099)
+    bank = customer.sources.create(source: bank_token)
+
+    expect(bank.customer).to eq('test_customer_sub')
+    expect(bank.last4).to eq("1123")
+    expect(bank.exp_month).to eq(11)
+    expect(bank.exp_year).to eq(2099)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.sources.count).to eq(1)
+    bank = customer.sources.data.first
+    expect(bank.customer).to eq('test_customer_sub')
+    expect(bank.last4).to eq("1123")
+    expect(bank.exp_month).to eq(11)
+    expect(bank.exp_year).to eq(2099)
+  end
+
+  it 'creates/returns a bank when using customer.sources.create given bank params' do
+    customer = Stripe::Customer.create(id: 'test_customer_sub')
+    bank = customer.sources.create(bank: {
+      number: '4242424242424242',
+      exp_month: '11',
+      exp_year: '3031',
+      cvc: '123'
+    })
+
+    expect(bank.customer).to eq('test_customer_sub')
+    expect(bank.last4).to eq("6789")
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.sources.count).to eq(1)
+    bank = customer.sources.data.first
+    expect(bank.customer).to eq('test_customer_sub')
+    expect(bank.last4).to eq("6789")
+  end
+
+  it "creates a single bank with a generated bank token", :live => true do
+    customer = Stripe::Customer.create
+    expect(customer.sources.count).to eq 0
+
+    customer.sources.create :source => stripe_helper.generate_bank_token
+    # Yes, stripe-ruby does not actually add the new bank to the customer instance
+    expect(customer.sources.count).to eq 0
+
+    customer2 = Stripe::Customer.retrieve(customer.id)
+    expect(customer2.sources.count).to eq 1
+    expect(customer2.default_source).to eq customer2.sources.first.id
+  end
+
+  it 'create does not change the customers default bank if already set' do
+    customer = Stripe::Customer.create(id: 'test_customer_sub', default_source: "test_cc_original")
+    bank_token = stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099)
+    bank = customer.sources.create(source: bank_token)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.default_source).to eq("test_cc_original")
+  end
+
+  it 'create updates the customers default bank if not set' do
+    customer = Stripe::Customer.create(id: 'test_customer_sub')
+    bank_token = stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099)
+    bank = customer.sources.create(source: bank_token)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.default_source).to_not be_nil
+  end
+
+  describe "retrieval and deletion with customers" do
+    let!(:customer) { Stripe::Customer.create(id: 'test_customer_sub') }
+    let!(:bank_token) { stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+    let!(:bank) { customer.sources.create(source: bank_token) }
+
+    it "can retrieve all customer's banks" do
+      retrieved = customer.sources.all
+      expect(retrieved.count).to eq(1)
+    end
+
+    it "retrieves a customers bank" do
+      retrieved = customer.sources.retrieve(bank.id)
+      expect(retrieved.to_s).to eq(bank.to_s)
+    end
+
+    it "retrieves a customer's bank after re-fetching the customer" do
+      retrieved = Stripe::Customer.retrieve(customer.id).sources.retrieve(bank.id)
+      expect(retrieved.id).to eq bank.id
+    end
+
+    it "deletes a customers bank" do
+      bank.delete
+      retrieved_cus = Stripe::Customer.retrieve(customer.id)
+      expect(retrieved_cus.sources.data).to be_empty
+    end
+
+    it "deletes a customers bank then set the default_bank to nil" do
+      bank.delete
+      retrieved_cus = Stripe::Customer.retrieve(customer.id)
+      expect(retrieved_cus.default_source).to be_nil
+    end
+
+    it "updates the default bank if deleted" do
+      bank.delete
+      retrieved_cus = Stripe::Customer.retrieve(customer.id)
+      expect(retrieved_cus.default_source).to be_nil
+    end
+
+    context "deletion when the user has two banks" do
+      let!(:bank_token_2) { stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+      let!(:bank_2) { customer.sources.create(source: bank_token_2) }
+
+      it "has just one bank anymore" do
+        bank.delete
+        retrieved_cus = Stripe::Customer.retrieve(customer.id)
+        expect(retrieved_cus.sources.data.count).to eq 1
+        expect(retrieved_cus.sources.data.first.id).to eq bank_2.id
+      end
+
+      it "sets the default_bank id to the last bank remaining id" do
+        bank.delete
+        retrieved_cus = Stripe::Customer.retrieve(customer.id)
+        expect(retrieved_cus.default_source).to eq bank_2.id
+      end
+    end
+  end
+
+  describe "Errors", :live => true do
+    it "throws an error when the customer does not have the retrieving bank id" do
+      customer = Stripe::Customer.create
+      bank_id = "bank_123"
+      expect { customer.sources.retrieve(bank_id) }.to raise_error {|e|
+        expect(e).to be_a Stripe::InvalidRequestError
+        expect(e.message).to match /no.*source/i
+        expect(e.message).to include bank_id
+        expect(e.param).to eq 'id'
+        expect(e.http_status).to eq 404
+      }
+    end
+  end
+
+  context "update bank" do
+    let!(:customer) { Stripe::Customer.create(id: 'test_customer_sub') }
+    let!(:bank_token) { stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099) }
+    let!(:bank) { customer.sources.create(source: bank_token) }
+
+    it "updates the bank" do
+      exp_month = 10
+      exp_year = 2098
+
+      bank.exp_month = exp_month
+      bank.exp_year = exp_year
+      bank.save
+
+      retrieved = customer.sources.retrieve(bank.id)
+
+      expect(retrieved.exp_month).to eq(exp_month)
+      expect(retrieved.exp_year).to eq(exp_year)
+    end
+  end
+
+  context "retrieve multiple banks" do
+
+    it "retrieves a list of multiple banks" do
+      customer = Stripe::Customer.create(id: 'test_customer_bank')
+
+      bank_token = stripe_helper.generate_bank_token(last4: "1123", exp_month: 11, exp_year: 2099)
+      bank1 = customer.sources.create(source: bank_token)
+      bank_token = stripe_helper.generate_bank_token(last4: "1124", exp_month: 12, exp_year: 2098)
+      bank2 = customer.sources.create(source: bank_token)
+
+      customer = Stripe::Customer.retrieve('test_customer_bank')
+
+      list = customer.sources.all
+
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(2)
+      expect(list.data.length).to eq(2)
+
+      expect(list.data.first.object).to eq("bank_account")
+      expect(list.data.first.to_hash).to eq(bank1.to_hash)
+
+      expect(list.data.last.object).to eq("bank_account")
+      expect(list.data.last.to_hash).to eq(bank2.to_hash)
+    end
+
+    it "retrieves an empty list if there's no subscriptions" do
+      Stripe::Customer.create(id: 'no_banks')
+      customer = Stripe::Customer.retrieve('no_banks')
+
+      list = customer.sources.all
+
+      expect(list.object).to eq("list")
+      expect(list.count).to eq(0)
+      expect(list.data.length).to eq(0)
+    end
+  end
+
+end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -11,6 +11,7 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Card Token Mocking', &block
   it_behaves_like 'Card API', &block
   it_behaves_like 'Charge API', &block
+  it_behaves_like 'Bank API', &block
   it_behaves_like 'Coupon API', &block
   it_behaves_like 'Customer API', &block
   it_behaves_like 'Dispute API', &block


### PR DESCRIPTION
This mostly adapts existing card flows to more general sources flows, and
adds bank account support along the way.

This is not a complete solution, but it improves support significantly.