### PR TITLE
Enable generating card and bank tokens without arguments

### DIFF
--- a/lib/stripe_mock/api/bank_tokens.rb
+++ b/lib/stripe_mock/api/bank_tokens.rb
@@ -1,6 +1,6 @@
 module StripeMock
 
-  def self.generate_bank_token(bank_params)
+  def self.generate_bank_token(bank_params = {})
     if @state == 'local'
       instance.generate_bank_token(bank_params)
     elsif @state == 'remote'

--- a/lib/stripe_mock/api/card_tokens.rb
+++ b/lib/stripe_mock/api/card_tokens.rb
@@ -1,6 +1,6 @@
 module StripeMock
 
-  def self.generate_card_token(card_params)
+  def self.generate_card_token(card_params = {})
     if @state == 'local'
       instance.generate_card_token(card_params)
     elsif @state == 'remote'

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -2,14 +2,14 @@ module StripeMock
   module RequestHandlers
     module Helpers
 
-      def generate_bank_token(bank_params)
+      def generate_bank_token(bank_params = {})
         token = new_id 'btok'
         bank_params[:id] = new_id 'bank_account'
         @bank_tokens[token] = Data.mock_bank_account bank_params
         token
       end
 
-      def generate_card_token(card_params)
+      def generate_card_token(card_params = {})
         token = new_id 'tok'
         card_params[:id] = new_id 'cc'
         @card_tokens[token] = Data.mock_card symbolize_names(card_params)

--- a/spec/shared_stripe_examples/bank_token_examples.rb
+++ b/spec/shared_stripe_examples/bank_token_examples.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 shared_examples 'Bank Account Token Mocking' do
 
+  it "generates a bank token with with default values" do
+    bank_token = StripeMock.generate_bank_token
+    tokens = test_data_source(:bank_tokens)
+    expect(tokens[bank_token]).to_not be_nil
+    expect(tokens[bank_token][:bank_name]).to eq("STRIPEMOCK TEST BANK")
+    expect(tokens[bank_token][:last4]).to eq("6789")
+  end
+
   it "generates a bank token with an associated account in memory" do
     bank_token = StripeMock.generate_bank_token(
       :bank_name => "Memory Bank",

--- a/spec/shared_stripe_examples/card_token_examples.rb
+++ b/spec/shared_stripe_examples/card_token_examples.rb
@@ -4,6 +4,16 @@ shared_examples 'Card Token Mocking' do
 
   describe 'Direct Token Creation' do
 
+    it "generates and reads a card token with default values" do
+      card_token = StripeMock.generate_card_token
+
+      charge = Stripe::Charge.create(amount: 500, currency: 'usd', source: card_token)
+      card = charge.source
+      expect(card.last4).to eq("4242")
+      expect(card.exp_month).to eq(4)
+      expect(card.exp_year).to eq(2016)
+    end
+
     it "generates and reads a card token for create charge" do
       card_token = StripeMock.generate_card_token(last4: "2244", exp_month: 33, exp_year: 2255)
 


### PR DESCRIPTION
Via StripeMock.generate_card_token and StripeMock.generate_bank_token.

Because sometimes you don't care about the token, so long as it is one.