### PR TITLE
Support old-style URLs

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -4,9 +4,9 @@ module StripeMock
 
       def Customers.included(klass)
         klass.add_handler 'post /v1/customers',                     :new_customer
-        klass.add_handler 'post /v1/customers/(.*)',                :update_customer
-        klass.add_handler 'get /v1/customers/(.*)',                 :get_customer
-        klass.add_handler 'delete /v1/customers/(.*)',              :delete_customer
+        klass.add_handler 'post /v1/customers/([^/]*)',             :update_customer
+        klass.add_handler 'get /v1/customers/([^/]*)',              :get_customer
+        klass.add_handler 'delete /v1/customers/([^/]*)',           :delete_customer
         klass.add_handler 'get /v1/customers',                      :list_customers
       end
 

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -3,11 +3,11 @@ module StripeMock
     module Subscriptions
 
       def Subscriptions.included(klass)
-        klass.add_handler 'get /v1/customers/(.*)/subscriptions', :retrieve_subscriptions
-        klass.add_handler 'post /v1/customers/(.*)/subscriptions', :create_subscription
-        klass.add_handler 'get /v1/customers/(.*)/subscriptions/(.*)', :retrieve_subscription
-        klass.add_handler 'post /v1/customers/(.*)/subscriptions/(.*)', :update_subscription
-        klass.add_handler 'delete /v1/customers/(.*)/subscriptions/(.*)', :cancel_subscription
+        klass.add_handler 'get /v1/customers/(.*)/subscription(?:s)?', :retrieve_subscriptions
+        klass.add_handler 'post /v1/customers/(.*)/subscription(?:s)?', :create_subscription
+        klass.add_handler 'get /v1/customers/(.*)/subscription(?:s)?/(.*)', :retrieve_subscription
+        klass.add_handler 'post /v1/customers/(.*)/subscription(?:s)?/(.*)', :update_subscription
+        klass.add_handler 'delete /v1/customers/(.*)/subscription(?:s)?/(.*)', :cancel_subscription
       end
 
       def create_subscription(route, method_url, params, headers)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -350,7 +350,7 @@ shared_examples 'Customer API' do
     expect(customer.deleted).to eq(true)
   end
   
-  it 'works with the update_subscription method', focus:true do
+  it 'works with the update_subscription method' do
     stripe_helper.create_plan(id: 'silver')
     cus   = Stripe::Customer.create(source: gen_card_tk)
     expect {

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -349,4 +349,13 @@ shared_examples 'Customer API' do
     customer = customer.delete
     expect(customer.deleted).to eq(true)
   end
+  
+  it 'works with the update_subscription method', focus:true do
+    stripe_helper.create_plan(id: 'silver')
+    cus   = Stripe::Customer.create(source: gen_card_tk)
+    expect {
+      cus.update_subscription(plan: 'silver')
+    }.not_to raise_error
+  end
+  
 end


### PR DESCRIPTION
Stripe has changed its URLs for subscriptions.

The Ruby library still uses old-style Stripe URLs in some situations at least (possibly all situations?).

This changes the regexps so that the mock server responds whichever style of URL is used. I found I needed this change to get subscriptions working.

Additionally, the customer regexps are tightened so they're not accidentally mistaken for subscription regexps.
