### PR TITLE
Add Support For Idempotent Charge Creation

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -13,8 +13,8 @@ module StripeMock
       end
 
       def new_charge(route, method_url, params, headers)
-        if params[:idempotency_key]
-          original_charge = charges.values.select { |c| c[:idempotency_key] == params[:idempotency_key]}.first
+        if params[:idempotency_key] && charges.any?
+          original_charge = charges.values.find { |c| c[:idempotency_key] == params[:idempotency_key]}
           return charges[original_charge[:id]] if original_charge
         end
 

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -13,6 +13,11 @@ module StripeMock
       end
 
       def new_charge(route, method_url, params, headers)
+        if params[:idempotency_key]
+          original_charge = charges.values.select { |c| c[:idempotency_key] == params[:idempotency_key]}.first
+          return charges[original_charge[:id]] if original_charge
+        end
+
         id = new_id('ch')
 
         if params[:source]

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -376,18 +376,29 @@ shared_examples 'Charge API' do
   end
 
   describe "idempotency" do
+    let(:idempotent_charge_params) {{
+      amount: 777,
+      currency: 'USD',
+      card: stripe_helper.generate_card_token,
+      capture: true,
+      idempotency_key: 'onceisenough'
+    }}
+
     it "returns the original charge if the same idempotency_key is passed in" do
-      charge_params = {
-        amount: 777,
-        currency: 'USD',
-        card: stripe_helper.generate_card_token,
-        capture: true,
-        idempotency_key: 'onceisenough'
-      }
-      charge1 = Stripe::Charge.create(charge_params)
-      charge2 = Stripe::Charge.create(charge_params)
+      charge1 = Stripe::Charge.create(idempotent_charge_params)
+      charge2 = Stripe::Charge.create(idempotent_charge_params)
 
       expect(charge1).to eq(charge2)
+    end
+
+    it "returns different charges if different idempotency_keys are used for each charge" do
+      idempotent_charge_params2 = idempotent_charge_params.clone
+      idempotent_charge_params2[:idempotency_key] = 'thisoneisdifferent'
+
+      charge1 = Stripe::Charge.create(idempotent_charge_params)
+      charge2 = Stripe::Charge.create(idempotent_charge_params2)
+
+      expect(charge1).not_to eq(charge2)
     end
   end
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -375,4 +375,20 @@ shared_examples 'Charge API' do
     end
   end
 
+  describe "idempotency" do
+    it "returns the original charge if the same idempotency_key is passed in" do
+      charge_params = {
+        amount: 777,
+        currency: 'USD',
+        card: stripe_helper.generate_card_token,
+        capture: true,
+        idempotency_key: 'onceisenough'
+      }
+      charge1 = Stripe::Charge.create(charge_params)
+      charge2 = Stripe::Charge.create(charge_params)
+
+      expect(charge1).to eq(charge2)
+    end
+  end
+
 end


### PR DESCRIPTION
`Stripe::Charge.create` now honors the `idempotency_key` parameter and returns the first instance of the charge created with that key in the current session.

This PR was motivated by this Issue: https://github.com/rebelidealist/stripe-ruby-mock/issues/234