### PR TITLE
Allow nil to be passed to StripeSubscription object as per the API during update_subscription

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -154,8 +154,8 @@ module StripeMock
         if params[:coupon]
           coupon_id = params[:coupon]
 
-          #remove discount if coupon_id is set to nil
-          return subscription[:discount] = nil if coupon_id == nil
+          # remove discount if coupon_id is set to nil
+          return subscription[:discount] = nil unless params[:coupon].present?
 
           # assert_existence returns 404 error code but Stripe returns 400
           # coupon = assert_existence :coupon, coupon_id, coupons[coupon_id]

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -154,16 +154,14 @@ module StripeMock
         if params[:coupon]
           coupon_id = params[:coupon]
 
-          # remove discount if coupon_id is set to nil
-          return subscription[:discount] = nil unless params[:coupon].present?
-
           # assert_existence returns 404 error code but Stripe returns 400
           # coupon = assert_existence :coupon, coupon_id, coupons[coupon_id]
 
           coupon = coupons[coupon_id]
-
           if coupon
             subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+          elsif coupon_id == ""
+            subscription[:discount] = Stripe::Util.convert_to_stripe_object(nil, {})
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', 400)
           end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -155,7 +155,7 @@ module StripeMock
           coupon_id = params[:coupon]
 
           #remove discount if coupon_id is set to nil
-          return subscription[:discount] = {} if nil
+          return subscription[:discount] = nil if coupon_id == nil
 
           # assert_existence returns 404 error code but Stripe returns 400
           # coupon = assert_existence :coupon, coupon_id, coupons[coupon_id]

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -154,6 +154,9 @@ module StripeMock
         if params[:coupon]
           coupon_id = params[:coupon]
 
+          #remove discount if coupon_id is set to nil
+          return subscription[:discount] = {} if nil
+
           # assert_existence returns 404 error code but Stripe returns 400
           # coupon = assert_existence :coupon, coupon_id, coupons[coupon_id]
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -360,6 +360,20 @@ shared_examples 'Customer Subscriptions' do
 
     end
 
+    it 'when coupon is removed' do
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon3', name: 'One More Test Plan', amount: 777)
+      customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
+      coupon = stripe_helper.create_coupon
+      subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+
+      subscription.coupon = coupon.id
+      subscription.save
+      subscription.coupon = nil
+      subscription.save
+
+      expect(subscription.discount).to be_nil
+    end
+
     it "throws an error when plan does not exist" do
       free = stripe_helper.create_plan(id: 'free', amount: 0)
       customer = Stripe::Customer.create(id: 'cardless', plan: 'free')


### PR DESCRIPTION
Possible fix for #364