### PR TITLE
Add external accounts

### DIFF
--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -38,6 +38,9 @@ module StripeMock
       @__list = [
         'account.updated',
         'account.application.deauthorized',
+        'account.external_account.created',
+        'account.external_account.updated',
+        'account.external_account.deleted',
         'balance.available',
         'charge.succeeded',
         'charge.failed',

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -47,6 +47,15 @@ module StripeMock
           date: nil,
           user_agent: nil
         },
+        external_accounts: {
+            object: "list",
+            data: [
+
+            ],
+            has_more: false,
+            total_count: 0,
+            url: "/v1/accounts/#{id}/external_accounts"
+        },
         legal_entity: {
           type: nil,
           business_name: nil,

--- a/lib/stripe_mock/webhook_fixtures/account.external_account.created.json
+++ b/lib/stripe_mock/webhook_fixtures/account.external_account.created.json
@@ -1,0 +1,27 @@
+{
+   "created":1326853478,
+   "livemode":false,
+   "id":"evt_00000000000000",
+   "type":"account.external_account.created",
+   "object":"event",
+   "data":{
+      "object":{
+         "id":"ba_00000000000000",
+         "object":"bank_account",
+         "account":"acct_00000000000000",
+         "account_holder_name":"Jane Austen",
+         "account_holder_type":"individual",
+         "bank_name":"STRIPE TEST BANK",
+         "country":"US",
+         "currency":"eur",
+         "default_for_currency":false,
+         "fingerprint":"efGCBmiwp56O1lsN",
+         "last4":"6789",
+         "metadata":{
+
+         },
+         "routing_number":"110000000",
+         "status":"new"
+      }
+   }
+}

--- a/lib/stripe_mock/webhook_fixtures/account.external_account.deleted.json
+++ b/lib/stripe_mock/webhook_fixtures/account.external_account.deleted.json
@@ -1,0 +1,27 @@
+{
+   "created":1326853478,
+   "livemode":false,
+   "id":"evt_00000000000000",
+   "type":"account.external_account.deleted",
+   "object":"event",
+   "data":{
+      "object":{
+         "id":"ba_00000000000000",
+         "object":"bank_account",
+         "account":"acct_00000000000000",
+         "account_holder_name":"Jane Austen",
+         "account_holder_type":"individual",
+         "bank_name":"STRIPE TEST BANK",
+         "country":"US",
+         "currency":"eur",
+         "default_for_currency":false,
+         "fingerprint":"efGCBmiwp56O1lsN",
+         "last4":"6789",
+         "metadata":{
+
+         },
+         "routing_number":"110000000",
+         "status":"new"
+      }
+   }
+}

--- a/lib/stripe_mock/webhook_fixtures/account.external_account.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/account.external_account.updated.json
@@ -1,0 +1,27 @@
+{
+   "created":1326853478,
+   "livemode":false,
+   "id":"evt_00000000000000",
+   "type":"account.external_account.updated",
+   "object":"event",
+   "data":{
+      "object":{
+         "id":"ba_00000000000000",
+         "object":"bank_account",
+         "account":"acct_00000000000000",
+         "account_holder_name":"Jane Austen",
+         "account_holder_type":"individual",
+         "bank_name":"STRIPE TEST BANK",
+         "country":"US",
+         "currency":"eur",
+         "default_for_currency":false,
+         "fingerprint":"efGCBmiwp56O1lsN",
+         "last4":"6789",
+         "metadata":{
+
+         },
+         "routing_number":"110000000",
+         "status":"new"
+      }
+   }
+}

--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -34,6 +34,9 @@ shared_examples 'Account API' do
       expect(account.keys).not_to be_nil
       expect(account.keys.secret).to match /sk_(live|test)_[\d\w]+/
       expect(account.keys.publishable).to match /pk_(live|test)_[\d\w]+/
+      expect(account.external_accounts).not_to be_nil
+      expect(account.external_accounts.data).to be_an Array
+      expect(account.external_accounts.url).to match /\/v1\/accounts\/.*\/external_accounts/
     end
   end
   describe 'updates account' do


### PR DESCRIPTION
This adds the external accounts support to the gem. It includes modifications on the `Data` module, new fixtures to handle related web hooks and a modification of events list to include the new web hooks.