### PR TITLE
Add zip code card error

### DIFF
--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -34,7 +34,8 @@ module StripeMock
         card_declined: add_json_body(["The card was declined", nil, 'card_declined', 402]),
         missing: add_json_body(["There is no card on a customer that is being charged.", nil, 'missing', 402]),
         processing_error: add_json_body(["An error occurred while processing the card", nil, 'processing_error', 402]),
-        card_error: add_json_body(['The card number is not a valid credit card number.', 'number', 'invalid_number', 402])
+        card_error: add_json_body(['The card number is not a valid credit card number.', 'number', 'invalid_number', 402]), 
+        incorrect_zip: add_json_body(['The zip code you supplied failed validation.', 'address_zip', 'incorrect_zip', 402])
       }
     end
 

--- a/spec/shared_stripe_examples/error_mock_examples.rb
+++ b/spec/shared_stripe_examples/error_mock_examples.rb
@@ -149,4 +149,9 @@ shared_examples 'Stripe Error Mocking' do
     expect_card_error 'processing_error', nil
   end
 
+  it "mocks an incorrect zip code card error" do
+    StripeMock.prepare_card_error(:incorrect_zip)
+    expect_card_error 'incorrect_zip', 'address_zip'
+  end
+
 end


### PR DESCRIPTION
Supports the `incorrect_zip` card error.
More details on the specific case: https://support.stripe.com/questions/zip-code-validation-failure

![screen shot 2016-09-16 at 3 58 49 pm](https://cloud.githubusercontent.com/assets/4617078/18603456/868f5442-7c26-11e6-8a09-755b7f926d6d.png)