### PR TITLE
Handle edge case when method agrument is Stripe::Token.

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -35,7 +35,8 @@ module StripeMock
       end
 
       def get_card_or_bank_by_token(token)
-        @card_tokens[token] || @bank_tokens[token] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token}", 'tok', 404))
+        token_id = token['id'] || token
+         @card_tokens[token_id] || @bank_tokens[token_id] || raise(Stripe::InvalidRequestError.new("Invalid token id: #{token_id}", 'tok', 404))
       end
 
     end


### PR DESCRIPTION
Stripe API allows to create customer via passing in `source` `Stripe::Token`, not just `token id`. For example, 
```
token = Stripe::Token.create(
        card: { number: card_number, exp_month: exp_month, exp_year:  exp_year, cvc: cvc }
      )
Stripe::Customer.create(
      source: token,
      email:  'example@post.dom',
      plan:   'stripe_plan_id'
    )
```
In that case, will be raised `Stripe::InvalidRequestError` from `stripe_ruby_mock` gem.