### PR TITLE
Add validations to Charge API

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -146,6 +146,8 @@ module StripeMock
           raise Stripe::InvalidRequestError.new("Invalid integer: #{params[:amount]}", 'amount', 400)
         elsif non_positive_charge_amount?(params)
           raise Stripe::InvalidRequestError.new('Invalid positive integer', 'amount', 400)
+        elsif params[:source].nil? && params[:customer].nil?
+          raise Stripe::InvalidRequestError.new('Must provide source or customer.', nil)
         end
       end
 

--- a/spec/list_spec.rb
+++ b/spec/list_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
 describe StripeMock::Data::List do
+  let(:stripe_helper) { StripeMock.create_test_helper }
+
   before :all do
     StripeMock.start
   end
@@ -33,9 +35,9 @@ describe StripeMock::Data::List do
   end
 
   it "eventually gets turned into a hash" do
-    charge1 = Stripe::Charge.create(amount: 1, currency: 'usd')
-    charge2 = Stripe::Charge.create(amount: 1, currency: 'usd')
-    charge3 = Stripe::Charge.create(amount: 1, currency: 'usd')
+    charge1 = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
+    charge2 = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
+    charge3 = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
     list = StripeMock::Data::List.new([charge1, charge2, charge3])
     hash = list.to_h
 
@@ -95,15 +97,17 @@ describe StripeMock::Data::List do
 
   context "pagination" do
     it "has a has_more field when it has more" do
-      list = StripeMock::Data::List.new([Stripe::Charge.create(amount: 1, currency: 'usd')] * 256)
+      list = StripeMock::Data::List.new(
+        [Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)] * 256
+      )
 
       expect(list).to have_more
     end
 
     it "accepts a starting_after parameter" do
       data = []
-      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd') }
-      new_charge = Stripe::Charge.create(amount: 1, currency: 'usd')
+      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
+      new_charge = Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
       data[89] = new_charge
       list = StripeMock::Data::List.new(data, starting_after: new_charge.id)
       hash = list.to_h
@@ -114,7 +118,7 @@ describe StripeMock::Data::List do
 
     it "raises an error if starting_after cursor is not found" do
       data = []
-      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd') }
+      255.times { data << Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
       list = StripeMock::Data::List.new(data, starting_after: "test_ch_unknown")
 
       expect { list.to_h }.to raise_error

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -24,7 +24,7 @@ describe 'StripeMock Server', :mock_server => true do
     charge = Stripe::Charge.create(
       amount: 987,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
     expect(charge.amount).to eq(987)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -12,11 +12,20 @@ shared_examples 'Charge API' do
     }.to raise_error(Stripe::InvalidRequestError, /token/i)
   end
 
+  it "requires a valid customer or source", :live => true do
+    expect {
+      charge = Stripe::Charge.create(
+        amount: 99,
+        currency: 'usd',
+      )
+    }.to raise_error(Stripe::InvalidRequestError, /Must provide source or customer/i)
+  end
+
   it "requires presence of amount", :live => true do
     expect {
       charge = Stripe::Charge.create(
         currency: 'usd',
-        card: stripe_helper.generate_card_token
+        source: stripe_helper.generate_card_token
       )
     }.to raise_error(Stripe::InvalidRequestError, /missing required param: amount/i)
   end
@@ -25,7 +34,7 @@ shared_examples 'Charge API' do
     expect {
       charge = Stripe::Charge.create(
         amount: 99,
-        card: stripe_helper.generate_card_token
+        source: stripe_helper.generate_card_token
       )
     }.to raise_error(Stripe::InvalidRequestError, /missing required param: currency/i)
   end
@@ -35,7 +44,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create(
         amount: -99,
         currency: 'usd',
-        card: stripe_helper.generate_card_token
+        source: stripe_helper.generate_card_token
       )
     }.to raise_error(Stripe::InvalidRequestError, /invalid positive integer/i)
   end
@@ -45,7 +54,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create(
         amount: 99.0,
         currency: 'usd',
-        card: stripe_helper.generate_card_token
+        source: stripe_helper.generate_card_token
       )
     }.to raise_error(Stripe::InvalidRequestError, /invalid integer/i)
   end
@@ -259,14 +268,14 @@ shared_examples 'Charge API' do
     charge1 = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
 
     charge2 = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
 
@@ -276,8 +285,9 @@ shared_examples 'Charge API' do
   context "retrieving a list of charges" do
     before do
       @customer = Stripe::Customer.create(email: 'johnny@appleseed.com')
+      @customer2 = Stripe::Customer.create(email: 'johnny2@appleseed.com')
       @charge = Stripe::Charge.create(amount: 1, currency: 'usd', customer: @customer.id)
-      @charge2 = Stripe::Charge.create(amount: 1, currency: 'usd')
+      @charge2 = Stripe::Charge.create(amount: 1, currency: 'usd', customer: @customer2.id)
     end
 
     it "stores charges for a customer in memory" do
@@ -289,12 +299,13 @@ shared_examples 'Charge API' do
     end
 
     it "defaults count to 10 charges" do
-      11.times { Stripe::Charge.create(amount: 1, currency: 'usd') }
+      11.times { Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
+
       expect(Stripe::Charge.all.data.count).to eq(10)
     end
 
     it "is marked as having more when more objects exist" do
-      11.times { Stripe::Charge.create(amount: 1, currency: 'usd') }
+      11.times { Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
 
       expect(Stripe::Charge.all.has_more).to eq(true)
     end
@@ -336,7 +347,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create({
         amount: 777,
         currency: 'USD',
-        card: stripe_helper.generate_card_token
+        source: stripe_helper.generate_card_token
       })
 
       expect(charge.captured).to eq(true)
@@ -346,7 +357,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create({
         amount: 777,
         currency: 'USD',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         capture: true
       })
 
@@ -357,7 +368,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create({
         amount: 777,
         currency: 'USD',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         capture: false
       })
 
@@ -370,7 +381,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create({
         amount: 777,
         currency: 'USD',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         capture: false
       })
 
@@ -384,7 +395,7 @@ shared_examples 'Charge API' do
       charge = Stripe::Charge.create({
         amount: 777,
         currency: 'USD',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         capture: false
       })
 
@@ -398,10 +409,11 @@ shared_examples 'Charge API' do
   end
 
   describe "idempotency" do
+    let(:customer) { Stripe::Customer.create(email: 'johnny@appleseed.com') }
     let(:idempotent_charge_params) {{
       amount: 777,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      customer: customer.id,
       capture: true,
       idempotency_key: 'onceisenough'
     }}

--- a/spec/shared_stripe_examples/country_specs_examples.rb
+++ b/spec/shared_stripe_examples/country_specs_examples.rb
@@ -4,12 +4,12 @@ shared_examples 'Country Spec API' do
   context 'retrieve country', live: true do
     it 'retrieves a stripe country spec' do
       country = Stripe::CountrySpec.retrieve('US')
-      
+
       expect(country).to be_a Stripe::CountrySpec
       expect(country.id).to match /US/
     end
 
-    it "cannot retrieve a stripe country that doesn't exist", focus: true do
+    it "cannot retrieve a stripe country that doesn't exist" do
       expect { Stripe::CountrySpec.retrieve('nope') }
           .to raise_error(Stripe::InvalidRequestError, /(nope is not currently supported by Stripe)|(Country 'nope' is unknown)/)
 

--- a/spec/shared_stripe_examples/error_mock_examples.rb
+++ b/spec/shared_stripe_examples/error_mock_examples.rb
@@ -64,7 +64,10 @@ shared_examples 'Stripe Error Mocking' do
     custom_error = StandardError.new("Please knock first.")
     StripeMock.prepare_error(custom_error, :new_customer)
 
-    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to_not raise_error
+    expect {
+      Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
+    }.to_not raise_error
+
     expect { Stripe::Customer.create }.to raise_error {|e|
       expect(e).to be_a StandardError
       expect(e.message).to eq("Please knock first.")
@@ -89,7 +92,9 @@ shared_examples 'Stripe Error Mocking' do
 
   it "mocks a card error with a given handler" do
     StripeMock.prepare_card_error(:incorrect_cvc, :new_customer)
-    expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to_not raise_error
+    expect {
+      Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token)
+    }.to_not raise_error
 
     expect { Stripe::Customer.create() }.to raise_error {|e|
       expect(e).to be_a(Stripe::CardError)

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -6,7 +6,7 @@ shared_examples 'Refund API' do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
 
@@ -21,7 +21,7 @@ shared_examples 'Refund API' do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
     refund = charge.refund
@@ -34,7 +34,7 @@ shared_examples 'Refund API' do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
     refund = charge.refund
@@ -47,7 +47,7 @@ shared_examples 'Refund API' do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
     refund = charge.refund
@@ -55,12 +55,12 @@ shared_examples 'Refund API' do
     expect(refund.refunds.data.count).to eq 1
     expect(refund.refunds.data.first.status).to eq("succeeded")
   end
-  
+
   it "creates a stripe refund with a different balance transaction than the charge" do
     charge = Stripe::Charge.create(
       amount: 999,
       currency: 'USD',
-      card: stripe_helper.generate_card_token,
+      source: stripe_helper.generate_card_token,
       description: 'card charge'
     )
     refund = charge.refund
@@ -69,7 +69,7 @@ shared_examples 'Refund API' do
   end
 
   it "creates a refund off a charge", :live => true do
-    original = Stripe::Charge.create(amount: 555, currency: 'USD', card: stripe_helper.generate_card_token)
+    original = Stripe::Charge.create(amount: 555, currency: 'USD', source: stripe_helper.generate_card_token)
 
     charge = Stripe::Charge.retrieve(original.id)
 
@@ -79,7 +79,7 @@ shared_examples 'Refund API' do
   end
 
   it "handles multiple refunds", :live => true do
-    original = Stripe::Charge.create(amount: 1100, currency: 'USD', card: stripe_helper.generate_card_token)
+    original = Stripe::Charge.create(amount: 1100, currency: 'USD', source: stripe_helper.generate_card_token)
 
     charge = Stripe::Charge.retrieve(original.id)
 
@@ -105,7 +105,7 @@ shared_examples 'Refund API' do
     charge = Stripe::Charge.create(
         amount: 999,
         currency: 'USD',
-        card: stripe_helper.generate_card_token,
+        source: stripe_helper.generate_card_token,
         description: 'card charge'
     )
     refund = Stripe::Refund.create(


### PR DESCRIPTION
```ruby
describe '#charge' do
  subject { Stripe::Charge.create(params) }
  let(:params) { { amount: 10, currency: 'usd' } }

  before { StripeMock.start }
  after { StripeMock.stop }

  it { expect { subject }.to raise_error(Stripe::InvalidRequestError) }
end

# => expected Stripe::InvalidRequestError but nothing was raised 
```

```ruby
Stripe::Charge.create({amount: 10, currency: 'usd'})
# => Stripe::InvalidRequestError: Must provide source or customer.
```

- [Either `source` or `customer` is required](https://stripe.com/docs/api?lang=ruby#create_charge-customer) in Charge API, so I added validations.
- There are specs passes `card` param to Charge API. But the API is [not allowed](https://stripe.com/docs/api?lang=ruby#create_charge) `card`, so I move from `card` to `source` param in almost specs.
