### PR TITLE
Do not create charges for subscriptions with free trials

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -26,9 +26,8 @@ module StripeMock
       end
 
       def add_subscription_to_customer(cus, sub)
-        id = new_id('ch')
-
         if sub[:trial_end].nil? || sub[:trial_end] == "now"
+          id = new_id('ch')
           charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount])
         end
 

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -27,7 +27,11 @@ module StripeMock
 
       def add_subscription_to_customer(cus, sub)
         id = new_id('ch')
-        charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount]) if sub[:trial_end].nil?
+
+        if sub[:trial_end].nil? || sub[:trial_end] == "now"
+          charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount])
+        end
+
         if cus[:currency].nil?
           cus[:currency] = sub[:plan][:currency]
         elsif cus[:currency] != sub[:plan][:currency]

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -27,7 +27,7 @@ module StripeMock
 
       def add_subscription_to_customer(cus, sub)
         id = new_id('ch')
-        charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount])
+        charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount]) if sub[:trial_end].nil?
         if cus[:currency].nil?
           cus[:currency] = sub[:plan][:currency]
         elsif cus[:currency] != sub[:plan][:currency]

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -203,6 +203,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.id).to eq(sub.id)
       expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
       expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+      expect(customer.charges.count).to eq(0)
     end
 
     it "subscribes a customer with no card to a free plan" do


### PR DESCRIPTION
Currently if we create a subscription to a plan with a free trial, StripeMock automatically adds a charge to the customer. This is not what Stripe does, and in fact it leads to StripeMock creating charges for customers who don't even have a source to pay the charge with - because you don't need a source to create a subscription if there is a free trial.

This teeny PR fixes that and modifies a test to prove it.