### PR TITLE
Allow for charge creation with bank token

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -29,7 +29,7 @@ module StripeMock
             if params[:customer]
               params[:source] = get_card(customers[params[:customer]], params[:source])
             else
-              params[:source] = get_card_by_token(params[:source])
+              params[:source] = get_card_or_bank_by_token(params[:source])
             end
           elsif params[:source][:id]
             raise Stripe::InvalidRequestError.new("Invalid token id: #{params[:source]}", 'card', 400)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -65,6 +65,21 @@ shared_examples 'Charge API' do
     expect(charge.status).to eq('succeeded')
   end
 
+  it "creates a stripe charge item with a bank token" do
+    charge = Stripe::Charge.create(
+      amount: 999,
+      currency: 'USD',
+      source: stripe_helper.generate_bank_token,
+      description: 'bank charge'
+    )
+
+    expect(charge.id).to match(/^test_ch/)
+    expect(charge.amount).to eq(999)
+    expect(charge.description).to eq('bank charge')
+    expect(charge.captured).to eq(true)
+    expect(charge.status).to eq('succeeded')
+  end
+
   it 'creates a stripe charge item with a customer', :live => true do
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',


### PR DESCRIPTION
Not sure when this change was made live in the API, but it's backwards compatible.  Let me know what you think!