### PR TITLE
Add StripeMock.mock method

### DIFF
--- a/lib/stripe_mock/api/instance.rb
+++ b/lib/stripe_mock/api/instance.rb
@@ -18,6 +18,16 @@ module StripeMock
     @state = 'ready'
   end
 
+  # Yield the given block between StripeMock.start and StripeMock.stop
+  def self.mock(&block)
+    begin
+      self.start
+      yield
+    ensure
+      self.stop
+    end
+  end
+
   def self.alias_stripe_method(new_name, method_object)
     Stripe.define_singleton_method(new_name) {|*args| method_object.call(*args) }
   end

--- a/spec/api/instance_spec.rb
+++ b/spec/api/instance_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe StripeMock do
+  describe ".mock" do
+    it "yields the given block between starting and stopping StripeMock" do
+      expect(StripeMock.instance).to be_nil
+      expect(StripeMock.state).to eq "ready"
+
+      StripeMock.mock do
+        expect(StripeMock.instance).to be_instance_of StripeMock::Instance
+        expect(StripeMock.state).to eq "local"
+      end
+
+      expect(StripeMock.instance).to be_nil
+      expect(StripeMock.state).to eq "ready"
+    end
+
+    it "stops StripeMock if the given block raises an exception" do
+      expect(StripeMock.instance).to be_nil
+      begin
+        StripeMock.mock do
+          raise "Uh-oh..."
+        end
+      rescue
+        expect(StripeMock.instance).to be_nil
+        expect(StripeMock.state).to eq "ready"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This method takes a block, and yields it between `StripeMock.start` and `StripeMock.stop`. This ensures we don't forget to call `StripeMock.stop` at the appropriate time.

For example:

```ruby
test ".stripe_customer fetches the account's Stripe::Customer from Stripe and returns it" do
  StripeMock.mock do
    customer = account.stripe_customer
    assert_equal Stripe::Customer, customer.class
  end
end
```

We use `begin ... ensure` to ensure that `StripeMock.stop` is called, even if the block raises an exception.

I wasn't 100% sure where the tests should go - let me know if they'd be more appropriate elsewhere and I can move them accordingly.