### PR TITLE
Expand balance transaction when retrieving an existing charge

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -49,12 +49,13 @@ module StripeMock
             params.merge :id => id,
             :balance_transaction => balance_transaction_id)
 
+        charge = charges[id].clone
         if params[:expand] == ['balance_transaction']
-          charges[id][:balance_transaction] =
+          charge[:balance_transaction] =
             balance_transactions[balance_transaction_id]
         end
 
-        charges[id]
+        charge
       end
 
       def update_charge(route, method_url, params, headers)
@@ -89,6 +90,7 @@ module StripeMock
         charge_id = $1 || params[:charge]
         charge = assert_existence :charge, charge_id, charges[charge_id]
 
+        charge = charge.clone
         if params[:expand] == ['balance_transaction']
           balance_transaction = balance_transactions[charge[:balance_transaction]]
           charge[:balance_transaction] = balance_transaction

--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -87,7 +87,14 @@ module StripeMock
       def get_charge(route, method_url, params, headers)
         route =~ method_url
         charge_id = $1 || params[:charge]
-        assert_existence :charge, charge_id, charges[charge_id]
+        charge = assert_existence :charge, charge_id, charges[charge_id]
+
+        if params[:expand] == ['balance_transaction']
+          balance_transaction = balance_transactions[charge[:balance_transaction]]
+          charge[:balance_transaction] = balance_transaction
+        end
+
+        charge
       end
 
       def capture_charge(route, method_url, params, headers)

--- a/lib/stripe_mock/request_handlers/refunds.rb
+++ b/lib/stripe_mock/request_handlers/refunds.rb
@@ -15,7 +15,7 @@ module StripeMock
           return refunds[original_refund[:id]] if original_refund
         end
 
-        charge = get_charge(route, method_url, params, headers)
+        charge = assert_existence :charge, params[:charge], charges[params[:charge]]
         params[:amount] ||= charge[:amount]
         id = new_id('re')
         bal_trans_params = {

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -197,12 +197,16 @@ shared_examples 'Charge API' do
   end
 
   it "can expand balance transaction when retrieving a charge" do
-    charge = Stripe::Charge.create({
+    original = Stripe::Charge.create({
       amount: 300,
       currency: 'USD',
-      source: stripe_helper.generate_card_token,
-      expand: ['balance_transaction']
+      source: stripe_helper.generate_card_token
     })
+    charge = Stripe::Charge.retrieve(
+      id: original.id,
+      expand: ['balance_transaction']
+    )
+
     expect(charge.balance_transaction).to be_a(Stripe::BalanceTransaction)
   end
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -174,7 +174,7 @@ shared_examples 'Charge API' do
     expect(bal_trans.source).to eq(charge.source)
   end
 
-  it "can expand balance transaction" do
+  it "can expand balance transaction when creating a charge" do
     charge = Stripe::Charge.create({
       amount: 300,
       currency: 'USD',
@@ -194,6 +194,16 @@ shared_examples 'Charge API' do
 
     expect(charge.id).to eq(original.id)
     expect(charge.amount).to eq(original.amount)
+  end
+
+  it "can expand balance transaction when retrieving a charge" do
+    charge = Stripe::Charge.create({
+      amount: 300,
+      currency: 'USD',
+      source: stripe_helper.generate_card_token,
+      expand: ['balance_transaction']
+    })
+    expect(charge.balance_transaction).to be_a(Stripe::BalanceTransaction)
   end
 
   it "cannot retrieve a charge that doesn't exist" do


### PR DESCRIPTION
- `Stripe::Charge.retrieve` includes balance transaction object if `expand: ['balance_transaction']` has been passed into params. 
- Added spec
