### PR TITLE
Have the data list object behave like Stripe by always putting "creat…

### DIFF
--- a/lib/stripe_mock/data/list.rb
+++ b/lib/stripe_mock/data/list.rb
@@ -7,6 +7,13 @@ module StripeMock
         @data = Array(data.clone)
         @limit = [[options[:limit] || 10, 100].min, 1].max # restrict @limit to 1..100
         @starting_after = options[:starting_after]
+        if @data.first.is_a?(Hash) && @data.first[:created]
+          @data.sort_by! { |x| x[:created] }
+          @data.reverse!
+        elsif @data.first.respond_to?(:created)
+          @data.sort_by { |x| x.created }
+          @data.reverse!
+        end
       end
 
       def url

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -310,7 +310,7 @@ shared_examples 'Charge API' do
     end
 
     it "stores all charges in memory" do
-      expect(Stripe::Charge.all.data.map(&:id)).to eq([@charge.id, @charge2.id])
+      expect(Stripe::Charge.all.data.map(&:id).reverse).to eq([@charge.id, @charge2.id])
     end
 
     it "defaults count to 10 charges" do

--- a/spec/shared_stripe_examples/dispute_examples.rb
+++ b/spec/shared_stripe_examples/dispute_examples.rb
@@ -79,7 +79,7 @@ shared_examples 'Dispute API' do
       disputes = Stripe::Dispute.all(limit: 3)
 
       expect(disputes.count).to eq(3)
-      expect(disputes.map &:id).to include('dp_05RsQX2eZvKYlo2C0FRTGSSA','dp_15RsQX2eZvKYlo2C0ERTYUIA', 'dp_25RsQX2eZvKYlo2C0ZXCVBNM')
+      expect(disputes.map &:id).to include('dp_95RsQX2eZvKYlo2C0EDFRYUI','dp_85RsQX2eZvKYlo2C0UJMCDET', 'dp_75RsQX2eZvKYlo2C0EDCXSWQ')
     end
 
   end

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -262,7 +262,7 @@ shared_examples 'Refund API' do
       end
 
       it "stores all charges in memory" do
-        expect(Stripe::Refund.all.data.map(&:id)).to eq([@refund.id, @refund2.id])
+        expect(Stripe::Refund.all.data.map(&:id)).to eq([@refund2.id, @refund.id])
       end
 
       it "defaults count to 10 charges" do

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -183,8 +183,8 @@ shared_examples 'Webhook Events API' do
       events = Stripe::Event.all(limit: 3)
 
       expect(events.count).to eq(3)
-      expect(events.map &:id).to include(customer_created_event.id, plan_created_event.id, coupon_created_event.id)
-      expect(events.map &:type).to include('customer.created', 'plan.created', 'coupon.created')
+      expect(events.map &:id).to include(invoice_item_created_event.id, invoice_created_event.id, coupon_created_event.id)
+      expect(events.map &:type).to include('invoiceitem.created', 'invoice.created', 'coupon.created')
     end
 
   end


### PR DESCRIPTION
…ed" in descending order

- Otherwise same time events will be assumed that when passed to the list,
  they have been pushed onto the list (where oldest will be first). This is
  to replicate the exact behavior of stripe

See #406 