### PR TITLE
Allow setting order status with a string

### DIFF
--- a/lib/stripe_mock/request_handlers/orders.rb
+++ b/lib/stripe_mock/request_handlers/orders.rb
@@ -45,7 +45,7 @@ module StripeMock
           end
         end
 
-        if [:created, :paid, :canceled, :fulfilled, :returned].includes? params[:status]
+        if [:created, :paid, :canceled, :fulfilled, :returned].include? params[:status]
           order[:status] = params[:status]
         end
         order

--- a/lib/stripe_mock/request_handlers/orders.rb
+++ b/lib/stripe_mock/request_handlers/orders.rb
@@ -45,7 +45,7 @@ module StripeMock
           end
         end
 
-        if [:created, :paid, :canceled, :fulfilled, :returned].include? params[:status]
+        if %w(created paid canceled fulfilled returned).include? params[:status]
           order[:status] = params[:status]
         end
         order


### PR DESCRIPTION
This fixes a typo where the method `includes?` was called instead of `include?`, which isn't valid. Additionally, this allows me to set an order status with a string, rather than a symbol, as I would probably do when working with the API directly. Looking briefly through the Subscriptions request handler, it seems that strings are used for status there as well.