### PR TITLE
Delete customer discount

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -8,6 +8,7 @@ module StripeMock
         klass.add_handler 'get /v1/customers/([^/]*)',              :get_customer
         klass.add_handler 'delete /v1/customers/([^/]*)',           :delete_customer
         klass.add_handler 'get /v1/customers',                      :list_customers
+        klass.add_handler 'delete /v1/customers/([^/]*)/discount',  :delete_customer_discount
       end
 
       def new_customer(route, method_url, params, headers)
@@ -114,6 +115,14 @@ module StripeMock
         Data.mock_list_object(customers.values, params)
       end
 
+      def delete_customer_discount(route, method_url, params, headers)
+        route =~ method_url
+        cus = assert_existence :customer, $1, customers[$1]
+      
+        cus[:discount] = nil
+        
+        cus
+      end
     end
   end
 end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -387,4 +387,18 @@ shared_examples 'Customer API' do
     }.not_to raise_error
   end
   
+  it "deletes a stripe customer discount" do
+    original = Stripe::Customer.create(id: 'test_customer_update')
+
+    coupon = Stripe::Coupon.create(id: "10PERCENT", duration: 'once')
+    original.coupon = coupon.id
+    original.save
+
+    expect(original.discount.coupon).to be_a Stripe::Coupon
+    
+    original.delete_discount
+
+    customer = Stripe::Customer.retrieve("test_customer_update")
+    expect(customer.discount).to be nil
+  end
 end


### PR DESCRIPTION
Added support for `DELETE /v1/customers/{CUSTOMER_ID}/discount`.