### PR TITLE
Add support for automatic Stripe transfers

### DIFF
--- a/lib/stripe_mock/client.rb
+++ b/lib/stripe_mock/client.rb
@@ -73,6 +73,10 @@ module StripeMock
       timeout_wrap { @pipe.clear_data }
     end
 
+    def upsert_stripe_object(object, attributes)
+      timeout_wrap { @pipe.upsert_stripe_object(object, attributes) }
+    end
+
     def close!
       self.cleanup
       StripeMock.stop_client(:clear_server_data => false)

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -113,6 +113,33 @@ module StripeMock
       @events[ event_data[:id] ] = symbolize_names(event_data)
     end
 
+    def upsert_stripe_object(object, attributes)
+      # Most Stripe entities can be created via the API.  However, some entities are created when other Stripe entities are
+      # created - such as when BalanceTransactions are created when Charges are created.  This method provides the ability
+      # to create these internal entities.
+      # It also provides the ability to modify existing Stripe entities.
+      id = attributes[:id]
+      if id.nil? || id == ""
+        # Insert new Stripe object
+        case object
+          when :balance_transaction
+            id = new_balance_transaction('txn', attributes)
+          else
+            raise UnsupportedRequestError.new "Unsupported stripe object `#{object}`"
+        end
+      else
+        # Update existing Stripe object
+        case object
+          when :balance_transaction
+            btxn = assert_existence :balance_transaction, id, @balance_transactions[id]
+            btxn.merge!(attributes)
+          else
+            raise UnsupportedRequestError.new "Unsupported stripe object `#{object}`"
+        end
+      end
+      id
+    end
+
     private
 
     def assert_existence(type, id, obj, message=nil)

--- a/lib/stripe_mock/request_handlers/balance_transactions.rb
+++ b/lib/stripe_mock/request_handlers/balance_transactions.rb
@@ -9,11 +9,27 @@ module StripeMock
 
       def get_balance_transaction(route, method_url, params, headers)
         route =~ method_url
-        assert_existence :balance_transaction, $1, balance_transactions[$1]
+        assert_existence :balance_transaction, $1, hide_additional_attributes(balance_transactions[$1])
       end
 
       def list_balance_transactions(route, method_url, params, headers)
-        Data.mock_list_object(balance_transactions.values, params)
+        values = balance_transactions.values
+        if params.has_key?(:transfer)
+          # If transfer supplied as params, need to filter the btxns returned to only include those with the specified transfer id
+          values = values.select{|btxn| btxn[:transfer] == params[:transfer]}
+        end
+        Data.mock_list_object(values.map{|btxn| hide_additional_attributes(btxn)}, params)
+      end
+
+      private
+
+      def hide_additional_attributes(btxn)
+        # For automatic Stripe transfers, the transfer attribute on balance_transaction stores the transfer which
+        # included this balance_transaction.  However, it is not exposed as a field returned on a balance_transaction.
+        # Therefore, need to not show this attribute if it exists.
+        if !btxn.nil?
+          btxn.reject{|k,v| k == :transfer }
+        end
       end
 
     end

--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -76,5 +76,10 @@ module StripeMock
     def ping
       true
     end
+
+    def upsert_stripe_object(object, attributes)
+      @instance.upsert_stripe_object(object, attributes)
+    end
+
   end
 end

--- a/lib/stripe_mock/test_strategies/live.rb
+++ b/lib/stripe_mock/test_strategies/live.rb
@@ -30,6 +30,11 @@ module StripeMock
           # do nothing
         end
       end
+
+      def upsert_stripe_object(object, attributes)
+        raise UnsupportedRequestError.new "Updating or inserting Stripe objects in Live mode not supported"
+      end
+
     end
   end
 end

--- a/lib/stripe_mock/test_strategies/mock.rb
+++ b/lib/stripe_mock/test_strategies/mock.rb
@@ -14,6 +14,14 @@ module StripeMock
         end
       end
 
+      def upsert_stripe_object(object, attributes = {})
+        if StripeMock.state == 'remote'
+          StripeMock.client.upsert_stripe_object(object, attributes)
+        elsif StripeMock.state == 'local'
+          StripeMock.instance.upsert_stripe_object(object, attributes)
+        end
+      end
+
     end
   end
 end

--- a/spec/shared_stripe_examples/balance_transaction_examples.rb
+++ b/spec/shared_stripe_examples/balance_transaction_examples.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 shared_examples 'Balance Transaction API' do
 
+  let(:stripe_helper) { StripeMock.create_test_helper }
+
   it "returns an error if balance transaction does not exist" do
     txn_id = 'txn_xxxxxxxxxxxxxxxxxxxxxxxx'
 
@@ -30,6 +32,32 @@ shared_examples 'Balance Transaction API' do
       expect(disputes.map &:id).to include('txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI')
     end
 
+  end
+
+  it 'retrieves balance transactions for an automated transfer' do
+    transfer_id = Stripe::Transfer.create({ amount: 2730, currency: "usd" })
+
+    # verify transfer currently has no balance transactions
+    transfer_transactions = Stripe::BalanceTransaction.all({transfer: transfer_id})
+    expect(transfer_transactions.count).to eq(0)
+
+    # verify we can create a new balance transaction associated with the transfer
+    new_txn_id = stripe_helper.upsert_stripe_object(:balance_transaction, {amount: 12300, transfer: transfer_id})
+    new_txn = Stripe::BalanceTransaction.retrieve(new_txn_id)
+    expect(new_txn).to be_a(Stripe::BalanceTransaction)
+    expect(new_txn.amount).to eq(12300)
+    # although transfer was specified as an attribute on the balance_transaction, it should not be returned in the object
+    expect{new_txn.transfer}.to raise_error(NoMethodError)
+
+    # verify we can update an existing balance transaction to associate with the transfer
+    existing_txn_id = 'txn_05RsQX2eZvKYlo2C0FRTGSSA'
+    existing_txn = Stripe::BalanceTransaction.retrieve(existing_txn_id)
+    stripe_helper.upsert_stripe_object(:balance_transaction, {id: existing_txn_id, transfer: transfer_id})
+
+    # now verify that only these balance transactions are retrieved with the transfer
+    transfer_transactions = Stripe::BalanceTransaction.all({transfer: transfer_id})
+    expect(transfer_transactions.count).to eq(2)
+    expect(transfer_transactions.map &:id).to include(new_txn_id, existing_txn_id)
   end
 
 end


### PR DESCRIPTION
Automatic Stripe transfers include specific balance_transactions.  To determine which balance_transactions are included in a specific transfer, you can use:

` Stripe::BalanceTransaction.all({transfer: 'tr_xxx'})`

However, this mock doesn't currently support the transfer keyword nor does it provide for linking balance_transactions with a specific transfer.

This pull request provides these capabilities.

- Add the `stripe_helper.upsert_stripe_object` method to insert or update balance_transactions with transfer id.
- Update the balance_transaction API methods to support the transfer keyword and not return the associated Stripe transfer id if present (since Stripe does not expose this value).

To use, do the following:
```
# create a transfer
transfer_id = Stripe::Transfer.create({ amount: 2730, currency: "usd" })

# Create a new balance transaction associated with the transfer
stripe_helper.upsert_stripe_object(:balance_transaction, {amount: 12300, transfer: transfer_id})

# Update an existing balance transaction to associate with the transfer
stripe_helper.upsert_stripe_object(:balance_transaction, {id: 'txn_05RsQX2eZvKYlo2C0FRTGSSA', transfer: transfer_id})

# Get all balance transactions associated with the transfer - should include only the 2 balance_transactions above
transfer_transactions = Stripe::BalanceTransaction.all({transfer: transfer_id})
```

Refer to the rspec for balance_transactions for complete details on how to use this new functionality.


