### PR TITLE
Handle case, when provided stripe customer object.

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -79,7 +79,8 @@ module StripeMock
         plan_id = params[:plan].to_s
         plan = assert_existence :plan, plan_id, plans[plan_id]
 
-        customer_id = params[:customer].to_s
+        customer = params[:customer]
+        customer_id = customer.is_a?(Stripe::Customer) ? customer[:id] : customer.to_s
         customer = assert_existence :customer, customer_id, customers[customer_id]
 
         if params[:source]


### PR DESCRIPTION
Stripe API allows to create subscription when passed  `Stripe::Customer` object.

```
customer = Stripe::Customer.create(description: "user\'s account description")
Stripe::Subscription.create(customer: customer, plan: 'some_stripe_plan_id')
```

`stripe_ruby_mock` gem handles just case, when `customer.id` passed, otherwise will be raised exception from [`:assert_existence`](https://github.com/rebelidealist/stripe-ruby-mock/blob/master/lib/stripe_mock/request_handlers/subscriptions.rb#L83) method.
