### PR TITLE
Conversion rate

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -26,6 +26,7 @@ require 'stripe_mock/api/client'
 require 'stripe_mock/api/server'
 
 require 'stripe_mock/api/bank_tokens'
+require 'stripe_mock/api/conversion_rate'
 require 'stripe_mock/api/card_tokens'
 require 'stripe_mock/api/debug'
 require 'stripe_mock/api/errors'

--- a/lib/stripe_mock/api/conversion_rate.rb
+++ b/lib/stripe_mock/api/conversion_rate.rb
@@ -1,0 +1,14 @@
+module StripeMock
+
+  def self.set_conversion_rate(value)
+    case @state
+    when 'local'
+      instance.conversion_rate = value
+    when 'remote'
+      client.set_conversion_rate(value)
+    else
+      raise UnstartedStateError
+    end
+  end
+
+end

--- a/lib/stripe_mock/client.rb
+++ b/lib/stripe_mock/client.rb
@@ -65,6 +65,14 @@ module StripeMock
       timeout_wrap { Stripe::Util.symbolize_names @pipe.generate_webhook_event(event_data) }
     end
 
+    def get_conversion_rate
+      timeout_wrap { @pipe.get_data(:conversion_rate) }
+    end
+
+    def set_conversion_rate(value)
+      timeout_wrap { @pipe.set_conversion_rate(value) }
+    end
+
     def destroy_resource(type, id)
       timeout_wrap { @pipe.destroy_resource(type, id) }
     end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -45,7 +45,7 @@ module StripeMock
                 :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
                 :refunds, :transfers, :subscriptions, :country_spec
 
-    attr_accessor :error_queue, :debug
+    attr_accessor :error_queue, :debug, :conversion_rate
 
     def initialize
       @accounts = {}
@@ -71,6 +71,7 @@ module StripeMock
       @error_queue = ErrorQueue.new
       @id_counter = 0
       @balance_transaction_counter = 0
+      @conversion_rate = 1.0
 
       # This is basically a cache for ParamValidators
       @base_strategy = TestStrategies::Base.new
@@ -135,6 +136,7 @@ module StripeMock
       unless amount.nil?
         # Fee calculation
         params[:fee] ||= (30 + (amount.abs * 0.029).ceil) * (amount > 0 ? 1 : -1)
+        params[:amount] = amount * @conversion_rate
       end
       @balance_transactions[id] = Data.mock_balance_transaction(params.merge(id: id))
       id

--- a/lib/stripe_mock/server.rb
+++ b/lib/stripe_mock/server.rb
@@ -65,6 +65,10 @@ module StripeMock
       @instance.generate_webhook_event(event_data)
     end
 
+    def set_conversion_rate(value)
+      @instance.conversion_rate = value
+    end
+
     def error_queue
       @instance.error_queue
     end

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -47,4 +47,9 @@ describe StripeMock::Instance do
     StripeMock.start
     expect(StripeMock.instance.debug).to eq(false)
   end
+
+  it "can set a conversion rate" do
+    StripeMock.set_conversion_rate(1.25)
+    expect(StripeMock.instance.conversion_rate).to eq(1.25)
+  end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -132,4 +132,8 @@ describe 'StripeMock Server', :mock_server => true do
     end
   end
 
+  it "can set a conversion rate" do
+    StripeMock.set_conversion_rate(1.2)
+    expect(StripeMock.client.get_conversion_rate).to eq(1.2)
+  end
 end

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -174,6 +174,22 @@ shared_examples 'Charge API' do
     expect(bal_trans.source).to eq(charge.source)
   end
 
+  context 'when conversion rate is set' do
+    it "balance transaction stores amount converted from charge currency to USD" do
+      StripeMock.set_conversion_rate(1.2)
+
+      charge = Stripe::Charge.create({
+        amount: 300,
+        currency: 'CAD',
+        source: stripe_helper.generate_card_token
+      })
+      bal_trans = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
+      expect(bal_trans.amount).to be > charge.amount
+      expect(bal_trans.fee).to eq(39)
+      expect(bal_trans.currency).to eq('usd')
+    end
+  end
+
   it "can expand balance transaction when creating a charge" do
     charge = Stripe::Charge.create({
       amount: 300,

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -184,7 +184,7 @@ shared_examples 'Charge API' do
         source: stripe_helper.generate_card_token
       })
       bal_trans = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
-      expect(bal_trans.amount).to be > charge.amount
+      expect(bal_trans.amount).to eq(charge.amount * 1.2)
       expect(bal_trans.fee).to eq(39)
       expect(bal_trans.currency).to eq('usd')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'pry'
 
 gem 'rspec', '~> 3.1'
 require 'rspec'
@@ -46,7 +47,7 @@ RSpec.configure do |c|
       StripeMock.stub(:stop).and_return(nil)
       Stripe.api_key = api_key
     end
-    c.after(:each) { sleep 1 }
+    c.after(:each) { sleep 0.01 }
   else
     c.filter_run_excluding :oauth => true
     Stripe.api_key ||= ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'set'
-require 'pry'
 
 gem 'rspec', '~> 3.1'
 require 'rspec'

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
   gem.add_development_dependency 'thin', '~> 1.6.4'
+  gem.add_development_dependency 'pry'
 end

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 3.1.0'
   gem.add_development_dependency 'rubygems-tasks', '~> 0.2'
   gem.add_development_dependency 'thin', '~> 1.6.4'
-  gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
#### Summary

Gives app developers an ability to write spec expectations for amounts converted from a charge currency to a destination/account currency.  

#### Details

We faced up with a task to have reports aggregating amounts of charges in different currencies. Obviously, all amounts have to be converted to a destination currency before they can be summed up. Stripe holds amounts in a destination currency in a `Stripe::BalanceTransaction.amount`. It's handy to store converted amount in app's DB for performance reasons.

`stripe-ruby-mock` stores in `Stripe::BalanceTransaction.amount` the same value as an underlying charge amount, so it is not possible to write expectations in specs if a given value is actually taken from the right place. This PR adds an ability to have a precise control over calculation of  `Stripe::BalanceTransaction.amount`: 

```ruby
# New method makes Stripe Mock to calculate `Stripe::BalanceTransaction.amount`
# as `amount = charge_amount * conversion_rate`. It gives app developers a predictable
# way to write spec expectations for converted amounts.  
StripeMock.set_conversion_rate(1.2)

charge = Stripe::Charge.create({
  amount: 
  currency: 'eur'
  source: stripe_helper.generate_card_token
})
bal_trans = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
# Charge amount and rate are known, thus it is possible to check 
# `Stripe::BalanceTransaction.amount`
expect(bal_trans.amount).to eq(charge.amount * 1.2)
```



