### PR TITLE
Webhook events: Add billing Items to the subscription

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
@@ -9,29 +9,40 @@
       "id": "su_00000000000000",
       "items": [
         {
-          "interval": "month",
-          "name": "Member's Club",
-          "amount": 100,
-          "currency": "usd",
-          "id": "fkx0AFo_00000000000000",
-          "object": "plan",
-          "livemode": false,
-          "interval_count": 1,
-          "trial_period_days": null,
-          "metadata": {}
+          "id": "si_00000000000000",
+          "object": "subscription_item",
+          "created": 1497881783,
+          "plan": {
+            "interval": "month",
+            "name": "Member's Club",
+            "amount": 100,
+            "currency": "usd",
+            "id": "fkx0AFo_00000000000000",
+            "object": "plan",
+            "livemode": false,
+            "interval_count": 1,
+            "trial_period_days": null,
+            "metadata": {}
+          },
+          "quantity": 1
         },
-
         {
-          "interval": "month",
-          "name": "Vistor's Club",
-          "amount": 200,
-          "currency": "eur",
-          "id": "fkx0AFo_00000000000001",
-          "object": "plan",
-          "livemode": false,
-          "interval_count": 1,
-          "trial_period_days": null,
-          "metadata": {}
+          "id": "si_00000000000001",
+          "object": "subscription_item",
+          "created": 1497881788,
+          "plan": {
+            "interval": "month",
+            "name": "Vistor's Club",
+            "amount": 200,
+            "currency": "eur",
+            "id": "fkx0AFo_00000000000001",
+            "object": "plan",
+            "livemode": false,
+            "interval_count": 1,
+            "trial_period_days": null,
+            "metadata": {}
+          },
+          "quantity": 5
         }
       ],
       "object": "subscription",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
@@ -7,44 +7,47 @@
   "data": {
     "object": {
       "id": "su_00000000000000",
-      "items": [
-        {
-          "id": "si_00000000000000",
-          "object": "subscription_item",
-          "created": 1497881783,
-          "plan": {
-            "interval": "month",
-            "name": "Member's Club",
-            "amount": 100,
-            "currency": "usd",
-            "id": "fkx0AFo_00000000000000",
-            "object": "plan",
-            "livemode": false,
-            "interval_count": 1,
-            "trial_period_days": null,
-            "metadata": {}
+        "items": {
+          "object": "list",
+          "data": [
+          {
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "id": "fkx0AFo_00000000000000",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 1
           },
-          "quantity": 1
-        },
-        {
-          "id": "si_00000000000001",
-          "object": "subscription_item",
-          "created": 1497881788,
-          "plan": {
-            "interval": "month",
-            "name": "Vistor's Club",
-            "amount": 200,
-            "currency": "eur",
-            "id": "fkx0AFo_00000000000001",
-            "object": "plan",
-            "livemode": false,
-            "interval_count": 1,
-            "trial_period_days": null,
-            "metadata": {}
-          },
-          "quantity": 5
-        }
-      ],
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "id": "fkx0AFo_00000000000001",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 5
+          }
+        ]
+      },
       "object": "subscription",
       "start": 1381080557,
       "status": "active",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
@@ -7,17 +7,33 @@
   "data": {
     "object": {
       "id": "su_00000000000000",
-      "plan": {
-        "interval": "month",
-        "name": "Member's Club",
-        "amount": 100,
-        "currency": "usd",
-        "id": "fkx0AFo_00000000000000",
-        "object": "plan",
-        "livemode": false,
-        "interval_count": 1,
-        "trial_period_days": null
-      },
+      "items": [
+        {
+          "interval": "month",
+          "name": "Member's Club",
+          "amount": 100,
+          "currency": "usd",
+          "id": "fkx0AFo_00000000000000",
+          "object": "plan",
+          "livemode": false,
+          "interval_count": 1,
+          "trial_period_days": null,
+          "metadata": {}
+        },
+
+        {
+          "interval": "month",
+          "name": "Vistor's Club",
+          "amount": 200,
+          "currency": "eur",
+          "id": "fkx0AFo_00000000000001",
+          "object": "plan",
+          "livemode": false,
+          "interval_count": 1,
+          "trial_period_days": null,
+          "metadata": {}
+        }
+      ],
       "object": "subscription",
       "start": 1381080557,
       "status": "active",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.deleted.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.deleted.json
@@ -7,16 +7,45 @@
   "data": {
     "object": {
       "id": "su_00000000000000",
-      "plan": {
-        "interval": "month",
-        "name": "Member's Club",
-        "amount": 100,
-        "currency": "usd",
-        "id": "fkx0AFo_00000000000000",
-        "object": "plan",
-        "livemode": false,
-        "interval_count": 1,
-        "trial_period_days": null
+      "items": {
+        "object": "list",
+        "data": [{
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "id": "fkx0AFo_00000000000000",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "id": "fkx0AFo_00000000000001",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 5
+          }
+        ]
       },
       "object": "subscription",
       "start": 1381080564,

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
@@ -7,16 +7,45 @@
   "data": {
     "object": {
       "id": "su_00000000000000",
-      "plan": {
-        "interval": "month",
-        "name": "Member's Club",
-        "amount": 100,
-        "currency": "usd",
-        "id": "fkx0AFo_00000000000000",
-        "object": "plan",
-        "livemode": false,
-        "interval_count": 1,
-        "trial_period_days": null
+      "items": {
+        "object": "list",
+        "data": [{
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "id": "fkx0AFo_00000000000000",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "id": "fkx0AFo_00000000000001",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 5
+          }
+        ]
       },
       "object": "subscription",
       "start": 1381080623,

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.updated.json
@@ -7,16 +7,45 @@
   "data": {
     "object": {
       "id": "su_00000000000000",
-      "plan": {
-        "interval": "month",
-        "name": "Member's Club",
-        "amount": 100,
-        "currency": "usd",
-        "id": "fkx0AFo_00000000000000",
-        "object": "plan",
-        "livemode": false,
-        "interval_count": 1,
-        "trial_period_days": null
+      "items": {
+        "object": "list",
+        "data": [{
+            "id": "si_00000000000000",
+            "object": "subscription_item",
+            "created": 1497881783,
+            "plan": {
+              "interval": "month",
+              "name": "Member's Club",
+              "amount": 100,
+              "currency": "usd",
+              "id": "fkx0AFo_00000000000000",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 1
+          },
+          {
+            "id": "si_00000000000001",
+            "object": "subscription_item",
+            "created": 1497881788,
+            "plan": {
+              "interval": "month",
+              "name": "Vistor's Club",
+              "amount": 200,
+              "currency": "eur",
+              "id": "fkx0AFo_00000000000001",
+              "object": "plan",
+              "livemode": false,
+              "interval_count": 1,
+              "trial_period_days": null,
+              "metadata": {}
+            },
+            "quantity": 5
+          }
+        ]
       },
       "object": "subscription",
       "start": 1381080561,

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
@@ -54,6 +54,39 @@
           "subscription": null,
           "subscription_item": "si_18ZfWyLrgDIZ7iq8fSlSNGIV",
           "type": "subscription"
+        },
+        {
+          "id": "sub_00000000000000",
+          "object": "line_item",
+          "amount": 50,
+          "currency": "eur",
+          "description": null,
+          "discountable": true,
+          "livemode": true,
+          "metadata": {},
+          "period": {
+            "start": 1500637196,
+            "end": 1532173196
+          },
+          "plan": {
+            "id": "gold",
+            "object": "plan",
+            "amount": 300,
+            "created": 1499943155,
+            "currency": "eur",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "name": "New gold Plan Test",
+            "statement_descriptor": null,
+            "trial_period_days": null
+          },
+          "proration": false,
+          "quantity": 1,
+          "subscription": null,
+          "subscription_item": "si_18ZfWyLrgDIZ7iq8fSlSNGIV",
+          "type": "subscription"
         }],
         "total_count": 1,
         "object": "list",

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
@@ -6,100 +6,74 @@
   "object": "event",
   "data": {
     "object": {
-      "date": 1394018368,
       "id": "in_00000000000000",
-      "period_start": 1394018368,
-      "period_end": 1394018368,
-      "lines": {
-        "object": "list",
-        "count": 3,
-        "url": "/v1/invoices/in_00000000000000/lines",
-        "data": [
-          {
-            "id": "ii_00000000000000",
-            "object": "line_item",
-            "type": "invoiceitem",
-            "livemode": false,
-            "amount": 19000,
-            "currency": "usd",
-            "proration": true,
-            "period": {
-              "start": 1393765661,
-              "end": 1393765661
-            },
-            "quantity": null,
-            "plan": null,
-            "description": "Remaining time on Platinum after 02 Mar 2014",
-            "metadata": {}
-          },
-          {
-            "id": "ii_00000000000001",
-            "object": "line_item",
-            "type": "invoiceitem",
-            "livemode": false,
-            "amount": -9000,
-            "currency": "usd",
-            "proration": true,
-            "period": {
-              "start": 1393765661,
-              "end": 1393765661
-            },
-            "quantity": null,
-            "plan": null,
-            "description": "Unused time on Gold after 05 Mar 2014",
-            "metadata": {}
-          },
-          {
-            "id": "su_00000000000000",
-            "object": "line_item",
-            "type": "subscription",
-            "livemode": false,
-            "amount": 20000,
-            "currency": "usd",
-            "proration": false,
-            "period": {
-              "start": 1383759053,
-              "end": 1386351053
-            },
-            "quantity": 1,
-            "plan": {
-              "interval": "month",
-              "name": "Platinum",
-              "created": 1300000000,
-              "amount": 20000,
-              "currency": "usd",
-              "id": "platinum",
-              "object": "plan",
-              "livemode": false,
-              "interval_count": 1,
-              "trial_period_days": null,
-              "metadata": {}
-            },
-            "description": null,
-            "metadata": null
-          }
-        ]
-      },
-      "subtotal": 30000,
-      "total": 30000,
-      "customer": "cus_00000000000000",
       "object": "invoice",
-      "attempted": true,
-      "closed": true,
-      "paid": true,
-      "livemode": false,
-      "attempt_count": 1,
-      "amount_due": 0,
-      "currency": "usd",
-      "starting_balance": 0,
-      "ending_balance": 0,
-      "next_payment_attempt": null,
-      "charge": "ch_00000000000000",
-      "discount": null,
+      "amount_due": 999,
       "application_fee": null,
-      "subscription": "su_00000000000000",
+      "attempt_count": 1,
+      "attempted": true,
+      "charge": "ch_18EcOcLrgDIZ7iq8TaNlErVv",
+      "closed": true,
+      "currency": "eur",
+      "customer": "cus_00000000000000",
+      "date": 1464084258,
+      "description": null,
+      "discount": null,
+      "ending_balance": 0,
+      "forgiven": false,
+      "lines": {
+        "data": [{
+          "id": "sub_00000000000000",
+          "object": "line_item",
+          "amount": 50,
+          "currency": "eur",
+          "description": null,
+          "discountable": true,
+          "livemode": true,
+          "metadata": {},
+          "period": {
+            "start": 1500637196,
+            "end": 1532173196
+          },
+          "plan": {
+            "id": "platinum",
+            "object": "plan",
+            "amount": 500,
+            "created": 1499943145,
+            "currency": "eur",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "name": "New Plan Test",
+            "statement_descriptor": null,
+            "trial_period_days": null
+          },
+          "proration": false,
+          "quantity": 1,
+          "subscription": null,
+          "subscription_item": "si_18ZfWyLrgDIZ7iq8fSlSNGIV",
+          "type": "subscription"
+        }],
+        "total_count": 1,
+        "object": "list",
+        "url": "/v1/invoices/in_18EcOcLrgDIZ7iq8zsDkunZ0/lines"
+      },
+      "livemode": false,
       "metadata": {},
-      "description": null
+      "next_payment_attempt": null,
+      "paid": true,
+      "period_end": 1464084258,
+      "period_start": 1464084258,
+      "receipt_number": null,
+      "starting_balance": 0,
+      "statement_descriptor": null,
+      "subscription": "sub_00000000000000",
+      "subtotal": 999,
+      "tax": null,
+      "tax_percent": null,
+      "total": 999,
+      "webhooks_delivered_at": 1464084258
     }
   }
 }

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -188,5 +188,58 @@ shared_examples 'Webhook Events API' do
     end
 
   end
+  
+  describe 'Subscription events' do 
+    it "Checks for billing items in customer.subscription.created" do 
+      subscription_created_event = StripeMock.mock_webhook_event('customer.subscription.created')
+      expect(subscription_created_event).to be_a(Stripe::Event)
+      expect(subscription_created_event.id).to_not be_nil
+      expect(subscription_created_event.data.object.items.data.class).to be Array
+      expect(subscription_created_event.data.object.items.data.length).to be 2
+      expect(subscription_created_event.data.object.items.data.first).to respond_to(:plan)
+      expect(subscription_created_event.data.object.items.data.first.id).to eq('si_00000000000000')
+    end
 
+    it "Checks for billing items in customer.subscription.deleted" do 
+      subscription_deleted_event = StripeMock.mock_webhook_event('customer.subscription.deleted')
+      expect(subscription_deleted_event).to be_a(Stripe::Event)
+      expect(subscription_deleted_event.id).to_not be_nil
+      expect(subscription_deleted_event.data.object.items.data.class).to be Array
+      expect(subscription_deleted_event.data.object.items.data.length).to be 2
+      expect(subscription_deleted_event.data.object.items.data.first).to respond_to(:plan)
+      expect(subscription_deleted_event.data.object.items.data.first.id).to eq('si_00000000000000')
+    end
+    
+    it "Checks for billing items in customer.subscription.updated" do 
+      subscription_updated_event = StripeMock.mock_webhook_event('customer.subscription.updated')
+      expect(subscription_updated_event).to be_a(Stripe::Event)
+      expect(subscription_updated_event.id).to_not be_nil
+      expect(subscription_updated_event.data.object.items.data.class).to be Array
+      expect(subscription_updated_event.data.object.items.data.length).to be 2
+      expect(subscription_updated_event.data.object.items.data.first).to respond_to(:plan)
+      expect(subscription_updated_event.data.object.items.data.first.id).to eq('si_00000000000000')
+    end
+    
+    it "Checks for billing items in customer.subscription.trial_will_end" do 
+      subscription_trial_will_end_event = StripeMock.mock_webhook_event('customer.subscription.trial_will_end')
+      expect(subscription_trial_will_end_event).to be_a(Stripe::Event)
+      expect(subscription_trial_will_end_event.id).to_not be_nil
+      expect(subscription_trial_will_end_event.data.object.items.data.class).to be Array
+      expect(subscription_trial_will_end_event.data.object.items.data.length).to be 2
+      expect(subscription_trial_will_end_event.data.object.items.data.first).to respond_to(:plan)
+      expect(subscription_trial_will_end_event.data.object.items.data.first.id).to eq('si_00000000000000')
+    end
+  end
+
+  describe 'Invoices events' do 
+    it "Checks for billing items in invoice.payment_succeeded" do
+      invoice_payment_succeeded = StripeMock.mock_webhook_event('invoice.payment_succeeded')
+      expect(invoice_payment_succeeded).to be_a(Stripe::Event)
+      expect(invoice_payment_succeeded.id).to_not be_nil
+      expect(invoice_payment_succeeded.data.object.lines.data.class).to be Array
+      expect(invoice_payment_succeeded.data.object.lines.data.length).to be 2
+      expect(invoice_payment_succeeded.data.object.lines.data.first).to respond_to(:plan)
+      expect(invoice_payment_succeeded.data.object.lines.data.first.id).to eq('sub_00000000000000')
+    end
+  end
 end


### PR DESCRIPTION
## Conext: 

Subscription now can have multiple plans in `items`

This PR referes to this open issue #429 