### PR TITLE
Stripe WebHooks no longer passes `user_id` param, instead it passes `…

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,9 @@ it "mocks a stripe webhook" do
 end
 
 it "mocks stripe connect webhooks" do
-  event = StripeMock.mock_webhook_event('customer.created', user_id: 'acc_123123')
+  event = StripeMock.mock_webhook_event('customer.created', account: 'acc_123123')
 
-  expect(event.user_id).to eq('acc_123123')
+  expect(event.account).to eq('acc_123123')
 end
 ```
 

--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -15,7 +15,7 @@ module StripeMock
 
     json = Stripe::Util.symbolize_names(json)
     params = Stripe::Util.symbolize_names(params)
-    json[:user_id] = params.delete(:user_id) if params.key?(:user_id)
+    json[:account] = params.delete(:account) if params.key?(:account)
     json[:data][:object] = Util.rmerge(json[:data][:object], params)
     json.delete(:id)
 

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -70,10 +70,10 @@ shared_examples 'Webhook Events API' do
     expect(data[event_b.id][:id]).to eq(event_b.id)
   end
 
-  it "handles stripe connect event when user_id is present" do
+  it "handles stripe connect event when account is present" do
   	acc_12314 = 'acc_12314'
-    event = StripeMock.mock_webhook_event('customer.created', user_id: acc_12314)
-    expect(event[:user_id]).to eq(acc_12314)
+    event = StripeMock.mock_webhook_event('customer.created', account: acc_12314)
+    expect(event[:account]).to eq(acc_12314)
   end
 
   it "retrieves an eveng using the event resource" do


### PR DESCRIPTION
…account`

I've switched out the references to user_id to be account as per
requested in #443 🎉