### PR TITLE
Add decline codes to CardError json

### DIFF
--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -39,11 +39,23 @@ module StripeMock
       }
     end
 
+    def self.get_decline_code(code)
+      decline_code_map = {
+        card_declined: 'do_not_honor',
+        missing: nil
+      }
+      decline_code_map.default = code.to_s
+
+      code_key = code.to_sym
+      decline_code_map[code_key]
+    end
+
     def self.add_json_body(error_values)
       error_keys = [:message, :param, :code]
 
       json_hash = Hash[error_keys.zip error_values]
       json_hash[:type] = 'card_error'
+      json_hash[:decline_code] = get_decline_code(json_hash[:code])
 
       error_values.last.merge!(json_body: { error: json_hash }, http_body: { error: json_hash })
 

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -25,6 +25,7 @@ describe 'README examples' do
       expect(e).to be_a Stripe::CardError
       expect(e.http_status).to eq(402)
       expect(e.code).to eq('card_declined')
+      expect(e.json_body[:error][:decline_code]).to eq('do_not_honor')
     }
   end
 


### PR DESCRIPTION
Stripe now includes [bank decline codes](https://stripe.com/docs/declines/codes) as a `decline_code` value in errors ( https://stripe.com/docs/api#errors ). These don't quite match 1 to 1 with the `code` value but are often close.

I've just added a `decline_code` value to the json parts of `CardError`