### PR TITLE
Correct invoice amount calculation for subscriptions with quantity above 1

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -85,9 +85,9 @@ module StripeMock
           id: subscription[:id],
           type: "subscription",
           plan: subscription[:plan],
-          amount: subscription[:plan][:amount],
+          amount: subscription[:plan][:amount] * subscription[:quantity],
           discountable: true,
-          quantity: 1,
+          quantity: subscription[:quantity],
           period: {
             start: subscription[:current_period_end],
             end: get_ending_time(subscription[:current_period_start], subscription[:plan], 2)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -139,7 +139,7 @@ shared_examples 'Invoice API' do
     it 'works when customer has a subscription', :live => true do
       plan = stripe_helper.create_plan(:id => 'has_sub')
       quantity = 3
-      subscription = Stripe::Subscription.create(plan: plan.id, customer: @customer.id, quantity: 3)
+      subscription = Stripe::Subscription.create(plan: plan.id, customer: @customer.id, quantity: quantity)
       upcoming = Stripe::Invoice.upcoming(customer: @customer.id)
 
       expect(upcoming).to be_a Stripe::Invoice

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -138,11 +138,13 @@ shared_examples 'Invoice API' do
 
     it 'works when customer has a subscription', :live => true do
       plan = stripe_helper.create_plan(:id => 'has_sub')
-      subscription = Stripe::Subscription.create(plan: plan.id, customer: @customer.id)
+      quantity = 3
+      subscription = Stripe::Subscription.create(plan: plan.id, customer: @customer.id, quantity: 3)
       upcoming = Stripe::Invoice.upcoming(customer: @customer.id)
 
       expect(upcoming).to be_a Stripe::Invoice
       expect(upcoming.customer).to eq(@customer.id)
+      expect(upcoming.amount_due).to eq plan.amount * quantity
       expect(upcoming.total).to eq(upcoming.lines.data[0].amount)
       expect(upcoming.period_end).to eq(upcoming.lines.data[0].period.start)
       expect(Time.at(upcoming.period_start).to_datetime >> 1).to eq(Time.at(upcoming.period_end).to_datetime) # +1 month


### PR DESCRIPTION
Updated upcoming invoice calculation to account for non-1 subscription quantity. Live tested with stripe.