### PR TITLE
Invoice subscription prorating/subscription previews; discount end date calculation, etc

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -313,7 +313,7 @@ module StripeMock
       in_id = params[:id] || "test_in_default"
       currency = params[:currency] || 'usd'
       lines << Data.mock_line_item() if lines.empty?
-      {
+      invoice = {
         id: 'in_test_invoice',
         date: 1349738950,
         period_end: 1349738950,
@@ -342,7 +342,7 @@ module StripeMock
         webhooks_delivered_at: 1349825350,
         livemode: false,
         attempt_count: 0,
-        amount_due: lines.map {|line| line[:amount]}.reduce(0, :+),
+        amount_due: nil,
         currency: currency,
         starting_balance: 0,
         ending_balance: nil,
@@ -351,6 +351,9 @@ module StripeMock
         discount: nil,
         subscription: nil
       }.merge(params)
+      due = invoice[:total] + invoice[:starting_balance]
+      invoice[:amount_due] = due < 0 ? 0 : due
+      invoice
     end
 
     def self.mock_line_item(params = {})

--- a/lib/stripe_mock/request_handlers/coupons.rb
+++ b/lib/stripe_mock/request_handlers/coupons.rb
@@ -12,6 +12,7 @@ module StripeMock
       def new_coupon(route, method_url, params, headers)
         params[:id] ||= new_id('coupon')
         raise Stripe::InvalidRequestError.new('Missing required param: duration', 'coupon', http_status: 400) unless params[:duration]
+        raise Stripe::InvalidRequestError.new('You must pass currency when passing amount_off', 'coupon', http_status: 400) if params[:amount_off] && !params[:currency]
         coupons[ params[:id] ] = Data.mock_coupon(params)
       end
 

--- a/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
@@ -4,6 +4,7 @@ module StripeMock
 
       def add_coupon_to_customer(customer, coupon)
         customer[:discount] = { coupon: coupon }
+        customer[:discount][:end] = (DateTime.now >> coupon[:duration_in_months]).to_time.to_i  if coupon[:duration].to_sym == :repeating && coupon[:duration_in_months]
 
         customer
       end

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -14,7 +14,7 @@ module StripeMock
         params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
         # TODO: Implement coupon logic
 
-        if (plan[:trial_period_days].nil? && options[:trial_end].nil?) || options[:trial_end] == "now"
+        if ((plan[:trial_period_days]||0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"
           end_time = get_ending_time(start_time, plan)
           params.merge!({status: 'active', current_period_end: end_time, trial_start: nil, trial_end: nil})
         else

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -59,23 +59,63 @@ module StripeMock
       def upcoming_invoice(route, method_url, params, headers)
         route =~ method_url
         raise Stripe::InvalidRequestError.new('Missing required param: customer', nil, http_status: 400) if params[:customer].nil?
+        raise Stripe::InvalidRequestError.new('When previewing changes to a subscription, you must specify either `subscription` or `subscription_plan`', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil? && params[:subscription_plan].nil?
+        raise Stripe::InvalidRequestError.new('Cannot specify proration date without specifying a subscription', nil, http_status: 400) if !params[:subscription_proration_date].nil? && params[:subscription].nil?
 
         customer = customers[params[:customer]]
         assert_existence :customer, params[:customer], customer
 
         raise Stripe::InvalidRequestError.new("No upcoming invoices for customer: #{customer[:id]}", nil, http_status: 404) if customer[:subscriptions][:data].length == 0
 
-        most_recent = customer[:subscriptions][:data].min_by { |sub| sub[:current_period_end] }
-        invoice_item = get_mock_subscription_line_item(most_recent)
+        subscription =
+          if params[:subscription]
+            customer[:subscriptions][:data].select{|s|s[:id] == params[:subscription]}.first
+          else
+            customer[:subscriptions][:data].min_by { |sub| sub[:current_period_end] }
+          end
+
+        subscription_plan_id = params[:subscription_plan]
+        if subscription_plan_id
+          subscription_plan = assert_existence :plan, subscription_plan_id, plans[subscription_plan_id.to_s]
+          preview_subscription = Data.mock_subscription
+          preview_subscription.merge!(custom_subscription_params(subscription_plan, customer, { trial_end: params[:subscription_trial_end] }))
+          preview_subscription[:id] = subscription[:id]
+          preview_subscription[:quantity] = params[:subscription_quantity] if params[:subscription_quantity]
+        else
+          preview_subscription = subscription
+        end
+
+        subscription_proration_date = params[:subscription_proration_date] || Time.now
+
+        invoice_lines = []
+
+        if params[:subscription_prorate] || params[:subscription_proration_date]
+          unused_amount = subscription[:plan][:amount] * subscription[:quantity] * (subscription[:current_period_end] - subscription_proration_date.to_i) / (subscription[:current_period_end] - subscription[:current_period_start])
+          invoice_lines << Data.mock_line_item(
+                                   id: new_id('ii'),
+                                   amount: -unused_amount,
+                                   description: 'Unused time',
+                                   plan: subscription[:plan],
+                                   period: {
+                                       start: subscription_proration_date.to_i,
+                                       end: subscription[:current_period_end]
+                                   },
+                                   quantity: subscription[:quantity],
+                                   proration: true
+          )
+        end
+
+        invoice_lines << get_mock_subscription_line_item(preview_subscription)
 
         id = new_id('in')
-        invoices[id] = Data.mock_invoice([invoice_item],
+        invoices[id] = Data.mock_invoice(invoice_lines,
           id: id,
           customer: customer[:id],
-          subscription: most_recent[:id],
-          period_start: most_recent[:current_period_start],
-          period_end: most_recent[:current_period_end],
-          next_payment_attempt: most_recent[:current_period_end] + 3600 )
+          starting_balance: customer[:account_balance],
+          subscription: preview_subscription[:id],
+          period_start: preview_subscription[:current_period_start],
+          period_end: preview_subscription[:current_period_end],
+          next_payment_attempt: preview_subscription[:current_period_end] + 3600 )
       end
 
       private
@@ -85,9 +125,9 @@ module StripeMock
           id: subscription[:id],
           type: "subscription",
           plan: subscription[:plan],
-          amount: subscription[:plan][:amount],
+          amount: subscription[:status] == 'trialing' ? 0 : subscription[:plan][:amount] * subscription[:quantity],
           discountable: true,
-          quantity: 1,
+          quantity: subscription[:quantity],
           period: {
             start: subscription[:current_period_end],
             end: get_ending_time(subscription[:current_period_start], subscription[:plan], 2)

--- a/spec/shared_stripe_examples/coupon_examples.rb
+++ b/spec/shared_stripe_examples/coupon_examples.rb
@@ -27,6 +27,12 @@ shared_examples 'Coupon API' do
                  expect(e.message).to match /duration/
              }
     end
+    it 'fails when a coupon is created without a currency when amount_off is specified' do
+      expect { Stripe::Coupon.create(id: '10OFF', duration: 'once', amount_off: 1000) }.to raise_error {|e|
+        expect(e).to be_a(Stripe::InvalidRequestError)
+        expect(e.message).to match /You must pass currency when passing amount_off/
+      }
+    end
   end
 
   context 'retrieve coupon', live: true do

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -217,6 +217,19 @@ shared_examples 'Customer API' do
     expect(customer.discount.coupon).to_not be_nil
   end
 
+  describe 'repeating coupon with duration limit', live: true do
+    let!(:coupon) { Stripe::Coupon.create(id: '10OFF', amount_off: 1000, currency: 'usd', duration: 'repeating', duration_in_months: 12) }
+    let!(:customer) { Stripe::Customer.create(coupon: '10OFF') }
+    it 'creates the discount with the end date', live: true do
+      discount = Stripe::Customer.retrieve(customer.id).discount
+      expect(discount).to_not be_nil
+      expect(discount.coupon).to_not be_nil
+      expect(discount.end).to be_within(1).of (Time.now + 365 * 24 * 3600).to_i
+    end
+    after { Stripe::Coupon.retrieve(coupon.id).delete }
+    after { Stripe::Customer.retrieve(customer.id).delete }
+  end
+
   it 'cannot create a customer with a coupon that does not exist' do
     expect{
       customer = Stripe::Customer.create(id: 'test_cus_no_coupon', coupon: '5OFF')

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -136,19 +136,99 @@ shared_examples 'Invoice API' do
         expect(e.message).to eq("No upcoming invoices for customer: #{@customer.id}") }
     end
 
-    it 'works when customer has a subscription', :live => true do
-      plan = stripe_helper.create_plan(:id => 'has_sub')
-      subscription = Stripe::Subscription.create(plan: plan.id, customer: @customer.id)
-      upcoming = Stripe::Invoice.upcoming(customer: @customer.id)
+    describe 'parameters validation' do
+      let!(:customer) { Stripe::Customer.create(source: stripe_helper.generate_card_token) }
+      it 'fails without a subscription or subscription plan if subscription proration date is specified', live: true do
+        expect { Stripe::Invoice.upcoming(customer: customer.id, subscription_proration_date: Time.now.to_i) }.to raise_error do |e|
+          expect(e).to be_a Stripe::InvalidRequestError
+          expect(e.http_status).to eq 400
+          expect(e.message).to eq 'When previewing changes to a subscription, you must specify either `subscription` or `subscription_plan`'
+        end
+      end
+      context 'with a plan' do
+        let!(:plan) { Stripe::Plan.create(id: '50m', amount: 5000, interval: 'month', name: '50m', currency: 'usd') }
+        it 'fails without a subscription if proration date is specified', live: true do
+          expect { Stripe::Invoice.upcoming(customer: customer.id, subscription_plan: plan.id, subscription_proration_date: Time.now.to_i) }.to raise_error do |e|
+            expect(e).to be_a Stripe::InvalidRequestError
+            expect(e.http_status).to eq 400
+            expect(e.message).to eq 'Cannot specify proration date without specifying a subscription'
+          end
+        end
+        after { plan.delete }
+      end
+      after { customer.delete }
+    end
 
-      expect(upcoming).to be_a Stripe::Invoice
-      expect(upcoming.customer).to eq(@customer.id)
-      expect(upcoming.total).to eq(upcoming.lines.data[0].amount)
-      expect(upcoming.period_end).to eq(upcoming.lines.data[0].period.start)
-      expect(Time.at(upcoming.period_start).to_datetime >> 1).to eq(Time.at(upcoming.period_end).to_datetime) # +1 month
-      expect(Time.at(upcoming.period_start).to_datetime >> 2).to eq(Time.at(upcoming.lines.data[0].period.end).to_datetime) # +1 month
-      expect(upcoming.next_payment_attempt).to eq(upcoming.period_end + 3600) # +1 hour
-      expect(upcoming.subscription).to eq(subscription.id)
+    describe 'with a customer and a plan' do
+      let!(:customer) { Stripe::Customer.create(source: stripe_helper.generate_card_token) }
+      let!(:plan) { Stripe::Plan.create(id: '50m', amount: 5000, interval: 'month', name: '50m', currency: 'usd') }
+
+      it 'works when customer has a subscription', :live => true do
+        # Given
+        quantity = 3
+        subscription = Stripe::Subscription.create(plan: plan.id, customer: customer.id, quantity: quantity)
+
+        # When
+        upcoming = Stripe::Invoice.upcoming(customer: customer.id)
+
+        # Then
+        expect(upcoming).to be_a Stripe::Invoice
+        expect(upcoming.customer).to eq(customer.id)
+        expect(upcoming.amount_due).to eq plan.amount * quantity
+        expect(upcoming.total).to eq(upcoming.lines.data[0].amount)
+        expect(upcoming.period_end).to eq(upcoming.lines.data[0].period.start)
+        expect(Time.at(upcoming.period_start).to_datetime >> 1).to eq(Time.at(upcoming.period_end).to_datetime) # +1 month
+        expect(Time.at(upcoming.period_start).to_datetime >> 2).to eq(Time.at(upcoming.lines.data[0].period.end).to_datetime) # +1 month
+        expect(upcoming.next_payment_attempt).to eq(upcoming.period_end + 3600) # +1 hour
+        expect(upcoming.subscription).to eq(subscription.id)
+      end
+
+      [false, true].each do |with_trial|
+        describe "prorating a subscription with a new plan, with_trial: #{with_trial}" do
+          let!(:new_plan) { Stripe::Plan.create(id: '100y', amount: 10000, interval: 'year', name: '100y', currency: 'usd') }
+          it 'prorates', live: true do
+            # Given
+            initial_quantity = 3
+            subscription = Stripe::Subscription.create(plan: plan.id, customer: customer.id, quantity: initial_quantity)
+            proration_date = Time.now + 5 * 24 * 3600 # 5 days later
+            new_quantity = 2
+            unused_amount = plan.amount * initial_quantity * (subscription.current_period_end - proration_date.to_i) / (subscription.current_period_end - subscription.current_period_start)
+            prorated_amount_due = new_plan.amount * new_quantity - unused_amount
+            credit_balance = 1000
+            customer.account_balance = -credit_balance
+            customer.save
+            query = { customer: customer.id, subscription: subscription.id, subscription_plan: new_plan.id, subscription_proration_date: proration_date.to_i, subscription_quantity: new_quantity }
+            query[:subscription_trial_end] = (DateTime.now >> 1).to_time.to_i if with_trial
+
+            # When
+            upcoming = Stripe::Invoice.upcoming(query)
+
+            # Then
+            expect(upcoming).to be_a Stripe::Invoice
+            expect(upcoming.customer).to eq(customer.id)
+            if with_trial
+              expect(upcoming.amount_due).to eq 0
+            else
+              expect(upcoming.amount_due).to be_within(1).of prorated_amount_due - credit_balance
+            end
+            expect(upcoming.starting_balance).to eq -credit_balance
+            expect(upcoming.ending_balance).to be_nil
+            expect(upcoming.subscription).to eq(subscription.id)
+            expect(upcoming.lines.data[0].proration).to be_truthy
+            expect(upcoming.lines.data[0].plan.id).to eq '50m'
+            expect(upcoming.lines.data[0].amount).to be_within(1).of -unused_amount
+            expect(upcoming.lines.data[0].quantity).to eq initial_quantity
+            expect(upcoming.lines.data[1].proration).to be_falsey
+            expect(upcoming.lines.data[1].plan.id).to eq '100y'
+            expect(upcoming.lines.data[1].amount).to eq with_trial ? 0 : 20000
+            expect(upcoming.lines.data[1].quantity).to eq new_quantity
+          end
+          after { new_plan.delete }
+        end
+      end
+
+      after { plan.delete }
+      after { customer.delete }
     end
 
     it 'sets the start and end of billing periods correctly when plan has an interval_count' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,8 +43,8 @@ RSpec.configure do |c|
     end
 
     c.before(:each) do
-      StripeMock.stub(:start).and_return(nil)
-      StripeMock.stub(:stop).and_return(nil)
+      allow(StripeMock).to receive(:start).and_return(nil)
+      allow(StripeMock).to receive(:stop).and_return(nil)
       Stripe.api_key = api_key
     end
     c.after(:each) { sleep 0.01 }


### PR DESCRIPTION
Changes:
- invoice previews now support prorating and preview of subscription changes
- invoice preview now considers account balance
- invoice preview now takes into account subscription quantity
- discount end date is now calculated for repeating coupons with a duration limit
(all changes come with specs and have been stripe tested)