### PR TITLE
Transfer response should include a metadata field.

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -582,6 +582,7 @@ module StripeMock
         :fee_details => [],
         :id => id,
         :livemode => false,
+        :metadata => {},
         :currency => currency,
         :object => "transfer",
         :date => 1304114826,

--- a/spec/shared_stripe_examples/transfer_examples.rb
+++ b/spec/shared_stripe_examples/transfer_examples.rb
@@ -11,6 +11,7 @@ shared_examples 'Transfer API' do
     expect(transfer.currency).to eq('usd')
     expect(transfer.recipient).to eq recipient.id
     expect(transfer.reversed).to eq(false)
+    expect(transfer.metadata).to eq({})
   end
 
   describe "listing transfers", skip: 'Stripe has deprecated Recipients' do
@@ -47,6 +48,7 @@ shared_examples 'Transfer API' do
     expect(transfer.amount).to eq(original.amount)
     expect(transfer.currency).to eq(original.currency)
     expect(transfer.recipient).to eq(original.recipient)
+    expect(transfer.metadata).to eq(original.metadata)
   end
 
   it "canceles a stripe transfer " do


### PR DESCRIPTION
Transfer response now includes a `metadata` field, as specified by the Stripe docs: https://stripe.com/docs/api#transfer_object