### PR TITLE
Added expand default_source option to Stripe::Customer.retrieve

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -108,7 +108,16 @@ module StripeMock
 
       def get_customer(route, method_url, params, headers)
         route =~ method_url
-        assert_existence :customer, $1, customers[$1]
+        customer = assert_existence :customer, $1, customers[$1]
+
+        customer = customer.clone
+        if params[:expand] == ['default_source']
+          customer[:default_source] = customer[:sources][:data].detect do |source|
+            source[:id] == customer[:default_source]
+          end
+        end
+
+        customer
       end
 
       def list_customers(route, method_url, params, headers)


### PR DESCRIPTION
```ruby
Stripe::Customer.retrieve(
  id: 'cust_123',
  expand: ['default_source']
)
```

Which returns the actual object of the default source, instead of the ID.