### PR TITLE
When setting a nil tos date stripe returns a 400 error

### DIFF
--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -49,6 +49,14 @@ shared_examples 'Account API' do
 
       expect(account.support_phone).to eq '1234567'
     end
+
+    it 'raises when sending an empty tos date' do
+      account = Stripe::Account.retrieve
+      account.tos_acceptance.date = nil
+      expect {
+        account.save
+      }.to raise_error
+    end
   end
 
   it 'deauthorizes the stripe account', live: false do


### PR DESCRIPTION
This simulates that same behaviour, so we can catch errors like that in tests.
I copied the same error message and status. The response from Stripe is:

```
{:error=>{:type=>"invalid_request_error", :message=>"Invalid integer: ", :param=>"tos_acceptance[date]"}}
```