### PR TITLE
Add balance transaction to disputes

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -611,8 +611,9 @@ module StripeMock
       {
         :id => id,
         :object => "dispute",
+        :balance_transaction => "txn_2dyYXXP90MN26R",
         :amount => 195,
-        :balance_transactions => [],
+        :balance_transactions => [OpenStruct.new(self.mock_balance_transaction(fee: 1500, amount: -1000))],
         :charge => "ch_15RsQR2eZvKYlo2CA8IfzCX0",
         :created => @timestamp += 1,
         :currency => currency,
@@ -897,18 +898,20 @@ module StripeMock
       currency = params[:currency] || 'usd'
       bt_id = params[:id] || 'test_txn_default'
       source = params[:source] || 'ch_test_charge'
+      amount = params[:amount] || 10000
+      fee = params[:fee] || 320
       {
         id: bt_id,
         object: "balance_transaction",
-        amount: 10000,
+        amount: amount,
         available_on: 1462406400,
         created: 1461880226,
         currency: currency,
         description: nil,
-        fee: 320,
+        fee: fee,
         fee_details: [
           {
-            amount: 320,
+            amount: fee,
             application: nil,
             currency: currency,
             description: "Stripe processing fees",


### PR DESCRIPTION
When processing disputes, Stripe links to a balance transaction.  Through this balance transaction, you can retrieve the fee charged.

I needed to be able to retrieve the balance transaction and corresponding fee when processing a dispute.  This PR adds that functionality.

Please feel free to provide comments, I'm happy to improve the PR as needed.  Thanks!


Per Stripe docs:
https://stripe.com/docs/api#dispute_object