### PR TITLE
Plan in items

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -103,7 +103,7 @@ module StripeMock
 
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
-      currency = params[:currency] || nil
+      currency = params[:currency] || 'usd'
       sources.each {|source| source[:customer] = cus_id}
       {
         email: 'stripe_mock@example.com',
@@ -950,6 +950,32 @@ module StripeMock
         },
         status: "pending",
         type: "charge"
+      }.merge(params)
+    end
+
+    def self.mock_subscription_item(params = {})
+      iid = params[:id] || 'test_txn_default'
+      {
+        id: iid,
+        object: 'subscription_item',
+        created: 1504716183,
+        metadata: {
+      },
+        plan: {
+          id: 'PER_USER_PLAN1',
+          object: 'plan',
+          amount: 1337,
+          created: 1504716177,
+          currency: 'usd',
+          interval: 'month',
+          interval_count: 1,
+          livemode: false,
+          metadata: {},
+          name: 'StripeMock Default Plan ID',
+          statement_descriptor: nil,
+          trial_period_days: nil
+        },
+        quantity: 2
       }.merge(params)
     end
   end

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -43,7 +43,7 @@ module StripeMock
 
     attr_reader :accounts, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
-                :refunds, :transfers, :subscriptions, :country_spec
+                :refunds, :transfers, :subscriptions, :country_spec, :subscriptions_items
 
     attr_accessor :error_queue, :debug, :conversion_rate
 
@@ -65,6 +65,7 @@ module StripeMock
       @refunds = {}
       @transfers = {}
       @subscriptions = {}
+      @subscriptions_items = []
       @country_spec = {}
 
       @debug = false

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -14,7 +14,7 @@ module StripeMock
         params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
         # TODO: Implement coupon logic
 
-        if ((plan[:trial_period_days]||0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"
+        if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"
           end_time = get_ending_time(start_time, plan)
           params.merge!({status: 'active', current_period_end: end_time, trial_start: nil, trial_end: nil})
         else
@@ -28,12 +28,16 @@ module StripeMock
       def add_subscription_to_customer(cus, sub)
         if sub[:trial_end].nil? || sub[:trial_end] == "now"
           id = new_id('ch')
-          charges[id] = Data.mock_charge(:id => id, :customer => cus[:id], :amount => sub[:plan][:amount])
+          charges[id] = Data.mock_charge(
+            :id => id,
+            :customer => cus[:id],
+            :amount => (sub[:plan] ? sub[:plan][:amount] : total_items_amount(sub[:items][:data]))
+          )
         end
 
         if cus[:currency].nil?
-          cus[:currency] = sub[:plan][:currency]
-        elsif cus[:currency] != sub[:plan][:currency]
+          cus[:currency] = sub[:items][:data][0][:plan][:currency]
+        elsif cus[:currency] != sub[:items][:data][0][:plan][:currency]
           raise Stripe::InvalidRequestError.new( "Can't combine currencies on a single customer. This customer has had a subscription, coupon, or invoice item with currency #{cus[:currency]}", 'currency', http_status: 400)
         end
         cus[:subscriptions][:total_count] = (cus[:subscriptions][:total_count] || 0) + 1
@@ -50,6 +54,8 @@ module StripeMock
       # `intervals` is set to 1 when calculating current_period_end from current_period_start & plan
       # `intervals` is set to 2 when calculating Stripe::Invoice.upcoming end from current_period_start & plan
       def get_ending_time(start_time, plan, intervals = 1)
+        return start_time unless plan
+
         case plan[:interval]
         when "week"
           start_time + (604800 * (plan[:interval_count] || 1) * intervals)
@@ -74,6 +80,19 @@ module StripeMock
         end
       end
 
+      def total_items_amount(items)
+        total = 0
+        items.each { |i| total += (i[:quantity] || 1) * i[:plan][:amount] }
+        total
+      end
+
+      def mock_subscription_items(items = [])
+        data = []
+        items.each do |i|
+          data << Data.mock_subscription_item(i.merge(plan: plans[i[:plan].to_s]))
+        end
+        data
+      end
     end
   end
 end

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -333,7 +333,6 @@ shared_examples 'Customer Subscriptions' do
 
       plan2 = stripe_helper.create_plan(id: 'PER_USER_PLAN1')
       customer = Stripe::Customer.create(
-        id: 'cus_ABC4',
         source: {
           object: 'card',
           exp_month: 11,

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -328,6 +328,33 @@ shared_examples 'Customer Subscriptions' do
       }
     end
 
+    it 'when plan defined inside items', live: true do
+      plan = stripe_helper.create_plan(id: 'BASE_PRICE_PLAN1')
+
+      plan2 = stripe_helper.create_plan(id: 'PER_USER_PLAN1')
+      customer = Stripe::Customer.create(
+        id: 'cus_ABC4',
+        source: {
+          object: 'card',
+          exp_month: 11,
+          exp_year: 2019,
+          number: '4242424242424242',
+          cvc: '123'
+        }
+      )
+      subscription = Stripe::Subscription.create(
+        customer: customer.id,
+        items: [
+          { plan: plan.id, quantity: 1 },
+          { plan: plan2.id, quantity: 2 }
+        ]
+      )
+
+      expect(subscription.id).to match /(test_su_|sub_).+/
+      expect(subscription.plan).to eq nil
+      expect(subscription.items.data[0].plan.id).to eq plan.id
+      expect(subscription.items.data[1].plan.id).to eq plan2.id
+    end
   end
 
   context "updating a subscription" do


### PR DESCRIPTION
- partially solved #429 
- 100% solved [example](https://github.com/rebelidealist/stripe-ruby-mock/issues/429#issuecomment-320040935) `Stripe::InvalidRequestError: No such plan`
- solved #464 

