### PR TITLE
Make "created" field on subscriptions dynamic

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -9,8 +9,10 @@ module StripeMock
       def custom_subscription_params(plan, cus, options = {})
         verify_trial_end(options[:trial_end]) if options[:trial_end]
 
-        start_time = options[:current_period_start] || Time.now.utc.to_i
-        params = { plan: plan, customer: cus[:id], current_period_start: start_time }
+        now = Time.now.utc.to_i
+        created_time = options[:created] || now
+        start_time = options[:current_period_start] || now
+        params = { plan: plan, customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
         # TODO: Implement coupon logic
 

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -94,7 +94,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -136,6 +136,22 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.tax_percent).to eq(20)
     end
 
+    it "correctly sets created when it's not provided as a parameter", live: true do
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      subscription = Stripe::Subscription.create({ plan: 'silver', customer: customer.id })
+
+      expect(subscription.created).to eq(subscription.current_period_start)
+    end
+
+    it "correctly sets created when it's provided as a parameter" do
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      subscription = Stripe::Subscription.create({ plan: 'silver', customer: customer.id, created: 1473576318 })
+
+      expect(subscription.created).to eq(1473576318)
+    end
+
     it "adds additional subscription to customer with existing subscription" do
       silver =  stripe_helper.create_plan(id: 'silver')
       gold =    stripe_helper.create_plan(id: 'gold')


### PR DESCRIPTION
Sometimes we may need to set subscription's `created` value to some specific date/time (e.g. if we want to figure out if a subscription is newly created or has already been renewed).

### Before:
Subscription's `created` field always had constant value which was impossible to change.

### After:
You can provide `created` in `Stripe::Subscription.create` call. By default, it will be set to current time and will be equal to `current_period_start`.