### PR TITLE
Update Stripe::Transfer with latest API attributes

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -592,31 +592,29 @@ module StripeMock
       currency = params[:currency] || 'usd'
       id = params[:id] || 'tr_test_transfer'
       {
-        :status => 'pending',
         :amount => 100,
-        :account => {
-          :object => 'bank_account',
-          :country => 'US',
-          :bank_name => 'STRIPE TEST BANK',
-          :last4 => '6789'
-        },
-        :recipient => 'test_recipient',
-        :fee => 0,
-        :fee_details => [],
+        :amount_reversed => 0,
+        :balance_transaction => "txn_2dyYXXP90MN26R",
         :id => id,
         :livemode => false,
         :metadata => {},
         :currency => currency,
         :object => "transfer",
-        :date => 1304114826,
+        :created => 1304114826,
         :description => "Transfer description",
         :reversed => false,
         :reversals => {
           :object => "list",
+          :data => [],
           :total_count => 0,
           :has_more => false,
           :url => "/v1/transfers/#{id}/reversals"
         },
+        :destination => "acct_164wxjKbnvuxQXGu",
+        :destination_payment => "py_164xRvKbnvuxQXGuVFV2pZo1",
+        :source_transaction => "ch_164xRv2eZvKYlo2Clu1sIJWB",
+        :source_type => "card",
+        :transfer_group => "group_ch_164xRv2eZvKYlo2Clu1sIJWB",
       }.merge(params)
     end
 

--- a/lib/stripe_mock/request_handlers/transfers.rb
+++ b/lib/stripe_mock/request_handlers/transfers.rb
@@ -10,13 +10,19 @@ module StripeMock
       end
 
       def get_all_transfers(route, method_url, params, headers)
-        if recipient = params[:recipient]
-          assert_existence :recipient, recipient, recipients[recipient]
+        extra_params = params.keys - [:created, :destination, :ending_before,
+          :limit, :starting_after, :transfer_group]
+        unless extra_params.empty?
+          raise Stripe::InvalidRequestError.new("Received unknown parameter: #{extra_params[0]}", extra_params[0].to_s, http_status: 400)
+        end
+
+        if destination = params[:destination]
+          assert_existence :destination, destination, accounts[destination]
         end
 
         _transfers = transfers.each_with_object([]) do |(_, transfer), array|
-          if recipient
-            array << transfer if transfer[:recipient] == recipient
+          if destination
+            array << transfer if transfer[:destination] == destination
           else
             array << transfer
           end


### PR DESCRIPTION
I noticed transfer attributes were out of date when I tried to access `created` but that didn't exist: https://stripe.com/docs/api#transfer_object

I left `recipient` in since that broke some tests and I'm not familiar enough with the code to do a better refactoring. Sorry if this is incomplete or insufficient with how the code handles API versioning or something. But it got me what I needed for mocking.