### PR TITLE
Don't store upcoming invoice in memory

### DIFF
--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -73,7 +73,7 @@ module StripeMock
           else
             customer[:subscriptions][:data].min_by { |sub| sub[:current_period_end] }
           end
-        
+
         if params[:subscription_proration_date] && !((subscription[:current_period_start]..subscription[:current_period_end]) === params[:subscription_proration_date])
           raise Stripe::InvalidRequestError.new('Cannot specify proration date outside of current subscription period', nil, http_status: 400)
         end
@@ -117,9 +117,8 @@ module StripeMock
         subscription_line = get_mock_subscription_line_item(preview_subscription)
         invoice_lines << subscription_line
 
-        id = new_id('in')
-        invoices[id] = Data.mock_invoice(invoice_lines,
-          id: id,
+        Data.mock_invoice(invoice_lines,
+          id: new_id('in'),
           customer: customer[:id],
           discount: customer[:discount],
           date: invoice_date,

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -362,6 +362,12 @@ shared_examples 'Invoice API' do
       expect(@upcoming.subscription).to eq(@shortsub.id)
     end
 
+    it 'does not store the stripe invoice in memory since its only a preview', with_subscription: true do
+      invoice = Stripe::Invoice.upcoming(customer: customer.id)
+      data = test_data_source(:invoices)
+      expect(data[invoice.id]).to be_nil
+    end
+
     context 'retrieving invoice line items' do
       it 'returns all line items for created invoice' do
         invoice = Stripe::Invoice.create(customer: customer.id)
@@ -378,7 +384,7 @@ shared_examples 'Invoice API' do
         plan = stripe_helper.create_plan()
         subscription = Stripe::Subscription.create(plan: plan.id, customer: customer.id)
         upcoming = Stripe::Invoice.upcoming(customer: customer.id)
-        line_items = upcoming.lines.all
+        line_items = upcoming.lines
 
         expect(upcoming).to be_a Stripe::Invoice
         expect(line_items.count).to eq(1)


### PR DESCRIPTION
The invoice does not actually exist, but is just a preview. It's not an invoice that should be retrieved along with all other invoices for a given customer.

Previously, if you tried to list all invoices for a customer after fetching the upcoming invoice, the upcoming invoice would be included in the list of all invoices for that customer.

For now I left the invoice ID in place, however in my testing, Stripe does not return an ID for an upcoming invoice (likely because it can't be retrieved by ID), however their API documentation suggests the return JSON of fetching the upcoming invoice would have an ID: https://stripe.com/docs/api#upcoming_invoice

I had to change fetching line items for an upcoming invoice so that it'd use the line items in the response, not query the API to get the line items, since that'd fail the test as you can't fetch line items for an invoice that is not stored in memory.