### PR TITLE
Support for recursive merging of hashes where the keys are arrays

### DIFF
--- a/lib/stripe_mock/util.rb
+++ b/lib/stripe_mock/util.rb
@@ -9,8 +9,14 @@ module StripeMock
         if oldval.is_a?(Array) && newval.is_a?(Array)
           oldval.fill(nil, oldval.length...newval.length)
           oldval.zip(newval).map {|elems|
-            elems[1].nil? ? elems[0] : rmerge(elems[0], elems[1])
-          }
+            if elems[1].nil?
+              elems[0]
+            elsif elems[1].is_a?(Hash) && elems[1].is_a?(Hash)
+              rmerge(elems[0], elems[1])
+            else
+              [elems[0], elems[1]]
+            end
+          }.flatten
         elsif oldval.is_a?(Hash) && newval.is_a?(Hash)
           rmerge(oldval, newval)
         else

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -19,12 +19,20 @@ describe StripeMock::Util do
       expect(result).to eq({ x: { y: 999, z: { m: 44, n: 55 } } })
     end
 
-    it "merges array elements" do
+    it "merges array elements (that are hashes)" do
       dest = { x: [ {a: 1}, {b: 2}, {c: 3} ] }
       source = { x: [ {a: 0}, {a: 0} ] }
       result = StripeMock::Util.rmerge(dest, source)
 
       expect(result).to eq({ x: [ {a: 0}, {a: 0, b: 2}, {c: 3} ] })
+    end
+
+    it "merges array elements (that are arrays)" do
+      dest = { x: [ 1, 2 ] }
+      source = { x: [ 3, 4 ] }
+      result = StripeMock::Util.rmerge(dest, source)
+
+      expect(result).to eq({ x: [ 1, 3, 2, 4 ] })
     end
 
     it "does not truncate the array when merging" do


### PR DESCRIPTION
When creating custom webhook fixtures, sometimes you need to override fields that are an array. For instance, a `Stripe::Product` has a field called `attributes`, whose value is an array. So the custom webhook fixture might look like:

```json
{
  "type": "product.created",
  "data": {
    "object": {
      "object": "product",
      "attributes": [
        "size",
        "color"
      ]
    }
  }
}
```

In cases where you try and specify a custom value for `attributes` when creating the mock webhook, it currently produces an error:

```ruby
StripeMock.mock_webhook_event('product.created', { attributes: ['length', 'width'] })
=> undefined method `merge' for "length":String
```

This PR adds support to the underlying `StripeMock::Util.rmerge` method, so that it can handle merging hashes whose values are arrays.