### PR TITLE
Array merging with nils

### DIFF
--- a/lib/stripe_mock/util.rb
+++ b/lib/stripe_mock/util.rb
@@ -14,7 +14,7 @@ module StripeMock
             elsif elems[1].is_a?(Hash) && elems[1].is_a?(Hash)
               rmerge(elems[0], elems[1])
             else
-              [elems[0], elems[1]]
+              [elems[0], elems[1]].compact
             end
           }.flatten
         elsif oldval.is_a?(Hash) && newval.is_a?(Hash)

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -27,7 +27,7 @@ describe StripeMock::Util do
       expect(result).to eq({ x: [ {a: 0}, {a: 0, b: 2}, {c: 3} ] })
     end
 
-    context "array elements (that are arrays)" do
+    context "array elements (that are simple values)" do
       it "merges arrays" do
         dest = { x: [ 1, 2 ] }
         source = { x: [ 3, 4 ] }

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -27,12 +27,38 @@ describe StripeMock::Util do
       expect(result).to eq({ x: [ {a: 0}, {a: 0, b: 2}, {c: 3} ] })
     end
 
-    it "merges array elements (that are arrays)" do
-      dest = { x: [ 1, 2 ] }
-      source = { x: [ 3, 4 ] }
-      result = StripeMock::Util.rmerge(dest, source)
+    context "array elements (that are arrays)" do
+      it "merges arrays" do
+        dest = { x: [ 1, 2 ] }
+        source = { x: [ 3, 4 ] }
+        result = StripeMock::Util.rmerge(dest, source)
 
-      expect(result).to eq({ x: [ 1, 3, 2, 4 ] })
+        expect(result).to eq({ x: [ 1, 3, 2, 4 ] })
+      end
+
+      it "ignores empty arrays" do
+        dest = { x: [] }
+        source = { x: [ 3, 4 ] }
+        result = StripeMock::Util.rmerge(dest, source)
+
+        expect(result).to eq({ x: [ 3, 4 ] })
+      end
+
+      it "removes nil values" do
+        dest = { x: [ 1, 2, nil ] }
+        source = { x: [ nil, 3, 4 ] }
+        result = StripeMock::Util.rmerge(dest, source)
+
+        expect(result).to eq({ x: [ 1, 2, 3, 4 ] })
+      end
+
+      it "respects duplicate values" do
+        dest = { x: [ 1, 2, 3 ] }
+        source = { x: [ 3, 4 ] }
+        result = StripeMock::Util.rmerge(dest, source)
+
+        expect(result).to eq({ x: [ 1, 3, 2, 4, 3 ] })
+      end
     end
 
     it "does not truncate the array when merging" do


### PR DESCRIPTION
Previously, merging two arrays using `StripeMock::Util.rmerge(array1, array2)` could result in an array that contained nil values if one array was empty, or if one of the arrays contained explicit `nil` values.

```ruby
array1 = [1, 2, nil]
array2 = [3, 4]
StripeMock::Util.rmerge(array1, array2)
=> [1, 3, 2, 4, nil]

array1 = []
array2 = [3,4]
StripeMock::Util.rmerge(array1, array2)
=> [nil, 3, nil, 4]
```

Given that the `.rmerge` method removes/ignores nil values when merging an array of hashes, this PR aims to make this behaviour the same when merging an array that contains non-hash values. This PR also adds some additional test coverage for these cases.