### PR TITLE
replace transfer with payout

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -12,7 +12,7 @@ module StripeMock
         timezone: "US/Pacific",
         details_submitted: false,
         charges_enabled: false,
-        transfers_enabled: false,
+        payouts_enabled: false,
         currencies_supported: [
           "usd"
         ],

--- a/lib/stripe_mock/webhook_fixtures/account.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/account.updated.json
@@ -11,7 +11,7 @@
       "statement_descriptor": "TEST",
       "details_submitted": true,
       "charge_enabled": false,
-      "transfer_enabled": false,
+      "payouts_enabled": false,
       "currencies_supported": [
         "USD"
       ],


### PR DESCRIPTION
In the new API, transfers_enabled was replaced with payouts_enabled