### PR TITLE
Add outcome field to Charge

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -190,6 +190,13 @@ module StripeMock
         invoice: nil,
         description: nil,
         dispute: nil,
+        outcome: {
+          network_status: "approved_by_network",
+          reason: nil,
+          risk_level: "normal",
+          seller_message: "Payment complete.",
+          type: "authorized"
+        },
         metadata: {
         }
       }.merge(params)


### PR DESCRIPTION
The field is documented in the API doc:
https://stripe.com/docs/api#charge_object-outcome

-------

Not sure why the tests are failing – I don't think the `outcome` param should ever be sent when saving, it is readonly. I'd be happy to work on fixing the tests for this, but I will need a pointer before; I dug quite a bit and couldn't figure out.