### PR TITLE
Add support for creating Stripe disputes 

### DIFF
--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -75,6 +75,7 @@ module StripeMock
       @error_queue = ErrorQueue.new
       @id_counter = 0
       @balance_transaction_counter = 0
+      @dispute_counter = 0
       @conversion_rate = 1.0
       @account_balance = 10000
 
@@ -130,6 +131,8 @@ module StripeMock
         case object
           when :balance_transaction
             id = new_balance_transaction('txn', attributes)
+          when :dispute
+            id = new_dispute('dp', attributes)
           else
             raise UnsupportedRequestError.new "Unsupported stripe object `#{object}`"
         end
@@ -139,6 +142,9 @@ module StripeMock
           when :balance_transaction
             btxn = assert_existence :balance_transaction, id, @balance_transactions[id]
             btxn.merge!(attributes)
+          when :dispute
+            dispute = assert_existence :dispute, id, @disputes[id]
+            dispute.merge!(attributes)
           else
             raise UnsupportedRequestError.new "Unsupported stripe object `#{object}`"
         end
@@ -171,6 +177,12 @@ module StripeMock
         params[:amount] = amount * @conversion_rate
       end
       @balance_transactions[id] = Data.mock_balance_transaction(params.merge(id: id))
+      id
+    end
+
+    def new_dispute(prefix, params = {})
+      id = "#{StripeMock.global_id_prefix}#{prefix}_#{@dispute_counter += 1}"
+      @disputes[id] = Data.mock_dispute(params.merge(id: id))
       id
     end
 


### PR DESCRIPTION
Because disputes originate from Stripe, there is no API method to create a dispute for a specific charge.  However, there may be cases where you have an existing charge that you'd like to dispute.  

This pull request adds the ability to create a dispute using whatever attributes you'd like to specify using the upsert_stripe_object method.  To use, do something like the following:

```
# create a charge
charge = Stripe::Charge.create(amount: 1000, currency: "usd", source: "token_visa")

# create a dispute for this charge
stripe_dispute_id = stripe_helper.upsert_stripe_object(:dispute, {amount: charge.amount, charge: charge.id})

# retrieve the dispute
stripe_dispute = Stripe::Dispute.retrieve(stripe_dispute_id)
```
