### PR TITLE
Adds billing attribute to mock subscription

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -285,6 +285,7 @@ module StripeMock
     def self.mock_subscription(params={})
       StripeMock::Util.rmerge({
         created: 1478204116,
+        billing: 'charge_automatically',
         current_period_start: 1308595038,
         current_period_end: 1308681468,
         status: 'trialing',

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -31,6 +31,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.id).to eq(sub.id)
       expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
       expect(customer.subscriptions.data.first.customer).to eq(customer.id)
+      expect(customer.subscriptions.data.first.billing).to eq('charge_automatically')
       expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
       expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
     end
@@ -46,6 +47,7 @@ shared_examples 'Customer Subscriptions' do
 
       expect(sub.object).to eq('subscription')
       expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(sub.billing).to eq('charge_automatically')
       expect(sub.metadata.foo).to eq( "bar" )
       expect(sub.metadata.example).to eq( "yes" )
 
@@ -60,7 +62,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
 
       expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-
+      expect(customer.subscriptions.data.first.billing).to eq('charge_automatically')
       expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
       expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
     end


### PR DESCRIPTION
Small fix to add billing attribute to mock subscription data. 

Changes made: 
- Billing attribute with default value of `charge_automatically` added to mock subscription.
- Expectations confirming that the billing attribute is present/equals default in specs. 

[Subscription object from Stripe for reference](https://stripe.com/docs/api#subscriptions)