### PR TITLE
Add the prorate parameter as valid for subscription create

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -110,7 +110,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)


### PR DESCRIPTION
Add the prorate parameter to the list of valid parameters when creating a subscription.

Technically speaking it doesn't make sense to prorate a subscription when you're creating it. It's use only has an effect when updating a subscription. However, the Stripe API accepts the parameter without issue when creating or updating a subscription. In cases where a piece of code is supposed to create a new subscription or update an existing subscription, and not prorate the change, supporting the parameter makes it easier on the developer without needing a complex code flow when updating vs creating.

This is a very minor change and should be inline with the goal of supporting the API as Stripe has implemented it. I didn't make any tests because it's quite simple but if you would like, I can make a test to verify this behavior.