### PR TITLE
Compare the currency of the customer and plan as a string

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -99,7 +99,7 @@ module StripeMock
         customer = assert_existence :customer, customer_id, customers[customer_id]
 
         if plan && customer
-          unless customer[:currency] == plan[:currency]
+          unless customer[:currency].to_s == plan[:currency].to_s
             raise Stripe::InvalidRequestError.new('lol', 'currency', http_status: 400)
           end
         end


### PR DESCRIPTION
Compare the customer currency and plan currency as strings.

It's possible that a customer could be registered without a currency and will get a default of `:usd` (symbol) and a plan may be created with a currency of `'usd'` (string). When comparing the two to ensure the currencies are the same, the comparison will fail due to the different types. This patch converts both currencies to strings before comparing them.