### PR TITLE
Support for API change for 2018-02-06

### DIFF
--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -6,7 +6,9 @@ module StripeMock
         currency = params[:currency] || 'usd'
         {
           :id => 'stripe_mock_default_plan_id',
-          :name => 'StripeMock Default Plan ID',
+          :product => {
+            :name => 'StripeMock Default Plan ID'
+          },
           :amount => 1337,
           :currency => currency,
           :interval => 'month'

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.created.json
@@ -16,7 +16,7 @@
             "created": 1497881783,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
+              "product": "pr_00000000000000",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo_00000000000000",
@@ -34,7 +34,7 @@
             "created": 1497881788,
             "plan": {
               "interval": "month",
-              "name": "Vistor's Club",
+              "product": "pr_00000000000001",
               "amount": 200,
               "currency": "eur",
               "id": "fkx0AFo_00000000000001",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.deleted.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.deleted.json
@@ -15,7 +15,7 @@
             "created": 1497881783,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
+              "product": "pr_00000000000000",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo_00000000000000",
@@ -33,7 +33,7 @@
             "created": 1497881788,
             "plan": {
               "interval": "month",
-              "name": "Vistor's Club",
+              "product": "pr_00000000000001",
               "amount": 200,
               "currency": "eur",
               "id": "fkx0AFo_00000000000001",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.trial_will_end.json
@@ -15,7 +15,7 @@
             "created": 1497881783,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
+              "product": "pr_00000000000000",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo_00000000000000",
@@ -33,7 +33,7 @@
             "created": 1497881788,
             "plan": {
               "interval": "month",
-              "name": "Vistor's Club",
+              "product": "pr_00000000000001",
               "amount": 200,
               "currency": "eur",
               "id": "fkx0AFo_00000000000001",

--- a/lib/stripe_mock/webhook_fixtures/customer.subscription.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/customer.subscription.updated.json
@@ -15,7 +15,7 @@
             "created": 1497881783,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
+              "product": "pr_00000000000000",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo_00000000000000",
@@ -33,7 +33,7 @@
             "created": 1497881788,
             "plan": {
               "interval": "month",
-              "name": "Vistor's Club",
+              "product": "pr_00000000000001",
               "amount": 200,
               "currency": "eur",
               "id": "fkx0AFo_00000000000001",
@@ -64,7 +64,7 @@
     "previous_attributes": {
       "plan": {
         "interval": "month",
-        "name": "Old plan",
+        "product": "pr_00000000000002",
         "amount": 100,
         "currency": "usd",
         "id": "OLD_PLAN_ID",

--- a/lib/stripe_mock/webhook_fixtures/invoice.created.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.created.json
@@ -30,7 +30,6 @@
             "quantity": 1,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo",
@@ -38,6 +37,7 @@
               "livemode": false,
               "interval_count": 1,
               "trial_period_days": null,
+              "product": "pr_00000000000000",
               "metadata": {}
             },
             "description": null,

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
@@ -64,7 +64,7 @@
             "quantity": 1,
             "plan": {
               "interval": "month",
-              "name": "Platinum",
+              "product": "pr_00000000000000",
               "created": 1300000000,
               "amount": 20000,
               "currency": "usd",

--- a/lib/stripe_mock/webhook_fixtures/invoice.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.updated.json
@@ -30,7 +30,7 @@
             "quantity": 1,
             "plan": {
               "interval": "month",
-              "name": "Member's Club",
+              "product": "pr_00000000000000",
               "amount": 100,
               "currency": "usd",
               "id": "fkx0AFo",

--- a/lib/stripe_mock/webhook_fixtures/plan.created.json
+++ b/lib/stripe_mock/webhook_fixtures/plan.created.json
@@ -7,7 +7,7 @@
   "data": {
     "object": {
       "interval": "month",
-      "name": "Member's Club",
+      "product": "pr_00000000000000",
       "amount": 100,
       "currency": "usd",
       "id": "fkx0AFo_00000000000000",

--- a/lib/stripe_mock/webhook_fixtures/plan.deleted.json
+++ b/lib/stripe_mock/webhook_fixtures/plan.deleted.json
@@ -7,7 +7,7 @@
   "data": {
     "object": {
       "interval": "month",
-      "name": "Member's Club",
+      "product": "pr_00000000000000",
       "amount": 100,
       "currency": "usd",
       "id": "fkx0AFo_00000000000000",

--- a/lib/stripe_mock/webhook_fixtures/plan.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/plan.updated.json
@@ -7,7 +7,7 @@
   "data": {
     "object": {
       "interval": "month",
-      "name": "Member's Club",
+      "product": "pr_00000000000000",
       "amount": 100,
       "currency": "usd",
       "id": "fkx0AFo_00000000000000",

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -8,7 +8,8 @@ shared_examples 'Customer Subscriptions' do
 
   context "creating a new subscription" do
     it "adds a new subscription to customer with none using items", :live => true do
-      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
       customer = Stripe::Customer.create(source: gen_card_tk)
 
       expect(customer.subscriptions.data).to be_empty
@@ -37,7 +38,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it "adds a new subscription to customer with none", :live => true do
-      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
       customer = Stripe::Customer.create(source: gen_card_tk)
 
       expect(customer.subscriptions.data).to be_empty
@@ -66,7 +68,7 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'when customer object provided' do
-      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' }, amount: 4999, currency: 'usd')
       customer = Stripe::Customer.create(source: gen_card_tk)
 
       expect(customer.subscriptions.data).to be_empty
@@ -100,13 +102,15 @@ shared_examples 'Customer Subscriptions' do
       customer = Stripe::Customer.create(source: gen_card_tk)
       expect(customer.subscriptions.count).to eq(0)
 
-      plan = stripe_helper.create_plan(id: :silver, name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: :silver, product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
       sub = Stripe::Subscription.create({ plan: 'silver', customer: customer.id })
       customer = Stripe::Customer.retrieve(customer.id)
       expect(sub.plan.to_hash).to eq(plan.to_hash)
       expect(customer.subscriptions.count).to eq(1)
 
-      plan = stripe_helper.create_plan(id: 'gold', name: 'Gold Plan', amount: 14999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'gold', product: { name: 'Gold Plan' },
+                                       amount: 14999, currency: 'usd')
       sub = Stripe::Subscription.create({ plan: 'gold', customer: customer.id })
       customer = Stripe::Customer.retrieve(customer.id)
       expect(sub.plan.to_hash).to eq(plan.to_hash)
@@ -114,7 +118,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'creates a charge for the customer', live: true do
-      stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999)
+      stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                amount: 4999)
 
       customer = Stripe::Customer.create(source: gen_card_tk)
       Stripe::Subscription.create({ plan: 'silver', customer: customer.id, metadata: { foo: "bar", example: "yes" } })
@@ -125,7 +130,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'contains coupon object', live: true do
-      plan = stripe_helper.create_plan(id: 'plan_with_coupon', name: 'One More Test Plan', amount: 777)
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon', product: { name: 'One More Test Plan' },
+                                       amount: 777)
       coupon = stripe_helper.create_coupon(id: 'free_coupon', duration: 'repeating', duration_in_months: 3)
       customer = Stripe::Customer.create(source: gen_card_tk)
       Stripe::Subscription.create(plan: plan.id, customer: customer.id, coupon: coupon.id)
@@ -139,7 +145,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'when coupon is not exist', live: true do
-      plan = stripe_helper.create_plan(id: 'plan_with_coupon', name: 'One More Test Plan', amount: 777)
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon', product: { name: 'One More Test Plan' },
+                                       amount: 777)
       customer = Stripe::Customer.create(source: gen_card_tk)
 
       expect { Stripe::Subscription.create(plan: plan.id, customer: customer.id, coupon: 'none') }.to raise_error {|e|
@@ -153,7 +160,9 @@ shared_examples 'Customer Subscriptions' do
       Stripe::Plan.create(
         :amount => 2500,
         :interval => 'month',
-        :name => 'Test plan',
+        :product => {
+          :name => 'Test plan'
+        },
         :currency => 'usd',
         :id => 'silver',
         :statement_description => "testPlan"
@@ -169,7 +178,8 @@ shared_examples 'Customer Subscriptions' do
 
     it "correctly sets created when it's not provided as a parameter", live: true do
       customer = Stripe::Customer.create(source: gen_card_tk)
-      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
       subscription = Stripe::Subscription.create({ plan: 'silver', customer: customer.id })
 
       expect(subscription.created).to eq(subscription.current_period_start)
@@ -177,7 +187,8 @@ shared_examples 'Customer Subscriptions' do
 
     it "correctly sets created when it's provided as a parameter" do
       customer = Stripe::Customer.create(source: gen_card_tk)
-      plan = stripe_helper.create_plan(id: 'silver', name: 'Silver Plan', amount: 4999, currency: 'usd')
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
       subscription = Stripe::Subscription.create({ plan: 'silver', customer: customer.id, created: 1473576318 })
 
       expect(subscription.created).to eq(1473576318)
@@ -505,7 +516,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'when adds coupon', live: true do
-      plan = stripe_helper.create_plan(id: 'plan_with_coupon2', name: 'One More Test Plan', amount: 777)
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon2', product: { name: 'One More Test Plan' },
+                                       amount: 777)
       coupon = stripe_helper.create_coupon
       customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
       subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
@@ -519,7 +531,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'when add not exist coupon' do
-      plan = stripe_helper.create_plan(id: 'plan_with_coupon3', name: 'One More Test Plan', amount: 777)
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon3', product: { name: 'One More Test Plan' },
+                                       amount: 777)
       customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
       subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
 
@@ -534,7 +547,8 @@ shared_examples 'Customer Subscriptions' do
     end
 
     it 'when coupon is removed' do
-      plan = stripe_helper.create_plan(id: 'plan_with_coupon3', name: 'One More Test Plan', amount: 777)
+      plan = stripe_helper.create_plan(id: 'plan_with_coupon3', product: { name: 'One More Test Plan' },
+                                       amount: 777)
       customer = Stripe::Customer.create(source: gen_card_tk, plan: plan.id)
       coupon = stripe_helper.create_coupon
       subscription = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
@@ -898,10 +912,13 @@ shared_examples 'Customer Subscriptions' do
 
     it "creates a stripe customer and subscribes them to a plan with meta data", :live => true do
 
-      stripe_helper.create_plan(
+      stripe_helper.
+        create_plan(
         :amount => 500,
         :interval => 'month',
-        :name => 'Sample Plan',
+        :product => {
+          :name => 'Sample Plan'
+        },
         :currency => 'usd',
         :id => 'Sample5'
       )


### PR DESCRIPTION
* Stripe.api_version = "2018-02-06"
* Place plan name in a hash under key product when
creating a plan.
* Plan objects come back with a product id rather
than a name.

* Per Stripe Docs:

Changes since API version 2017-12-14:

Each plan object is now linked to a product object with type=service.
The plan object fields statement_descriptor and name attributes have been
moved to product objects. Creating a plan now requires passing a product
attribute to POST /v1/plans. This may be either an existing product ID
or a dictionary of product fields, so that you may continue to create
plans without separately creating products.