### PR TITLE
Support mocking Stripe requests in separate threads

### DIFF
--- a/lib/stripe_mock/api/client.rb
+++ b/lib/stripe_mock/api/client.rb
@@ -8,7 +8,7 @@ module StripeMock
     return false if @state == 'live'
     return @client unless @client.nil?
 
-    alias_stripe_method :execute_request, StripeMock.method(:redirect_to_mock_server)
+    Stripe::StripeClient.send(:define_method, :execute_request) { |*args| StripeMock.redirect_to_mock_server(*args) }
     @client = StripeMock::Client.new(port)
     @state = 'remote'
     @client
@@ -18,7 +18,7 @@ module StripeMock
     return false unless @state == 'remote'
     @state = 'ready'
 
-    alias_stripe_method :request, @original_request_method
+    restore_stripe_execute_request_method
     @client.clear_server_data if opts[:clear_server_data] == true
     @client.cleanup
     @client = nil

--- a/lib/stripe_mock/api/instance.rb
+++ b/lib/stripe_mock/api/instance.rb
@@ -2,18 +2,18 @@ module StripeMock
 
   @state = 'ready'
   @instance = nil
-  @original_request_method = Stripe::StripeClient.active_client.method(:execute_request)
+  @original_execute_request_method = Stripe::StripeClient.instance_method(:execute_request)
 
   def self.start
     return false if @state == 'live'
-    @instance = Instance.new
-    alias_stripe_method :execute_request, @instance.method(:mock_request)
+    @instance = instance = Instance.new
+    Stripe::StripeClient.send(:define_method, :execute_request) { |*args| instance.mock_request(*args) }
     @state = 'local'
   end
 
   def self.stop
     return unless @state == 'local'
-    alias_stripe_method :execute_request, @original_request_method
+    restore_stripe_execute_request_method
     @instance = nil
     @state = 'ready'
   end
@@ -28,8 +28,8 @@ module StripeMock
     end
   end
 
-  def self.alias_stripe_method(new_name, method_object)
-    Stripe::StripeClient.active_client.define_singleton_method(new_name) {|*args| method_object.call(*args) }
+  def self.restore_stripe_execute_request_method
+    Stripe::StripeClient.send(:define_method, :execute_request, @original_execute_request_method)
   end
 
   def self.instance; @instance; end


### PR DESCRIPTION
As of stripe v3.5.1 (https://github.com/stripe/stripe-ruby/commit/a210c5cd76f9178b5253b01c845076f2ac3f5e0a), the default client was memoized per-thread, therefore we were only mocking requests made on the same thread the tests ran on. If a Stripe request was made in a separate thread (such as a Rails feature/system test), it'd go right to Stripe.

Now we'll mock requests from any Stripe client instance instead of just the one for this thread.

I'm not sure if this is the right/best way to do this, using the private `define_method` seems wrong, but this was enough to solve the problem.

Probably fixes #504, #508, and #516.