### PR TITLE
allow destination field on charge update + test

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -160,7 +160,7 @@ module StripeMock
       end
 
       def allowed_params(params)
-        allowed = [:description, :metadata, :receipt_email, :fraud_details, :shipping]
+        allowed = [:description, :metadata, :receipt_email, :fraud_details, :shipping, :destination]
 
         # This is a workaround for the way the Stripe API sends params even when they aren't modified.
         # Stipe will include those params even when they aren't modified.

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -257,6 +257,23 @@ shared_examples 'Charge API' do
     expect(updated.fraud_details.to_hash).to eq(charge.fraud_details.to_hash)
   end
 
+  it "updates a stripe charge with no changes" do
+    original = Stripe::Charge.create({
+      amount: 777,
+      currency: 'USD',
+      source: stripe_helper.generate_card_token,
+      description: 'Original description',
+      destination: {
+        account: "acct_SOMEBOGUSID",
+        amount: 150
+      }
+    })
+
+    expect {
+      updated = original.save
+    }.not_to raise_error
+  end
+
   it "marks a charge as safe" do
     original = Stripe::Charge.create({
       amount: 777,


### PR DESCRIPTION
Changes:
- allow the `destination` field on charge updates

Tests:
- validate that you can successfully save a Charge that doesn't have any changes made to it, which failed before in the case of `destination` since it was allowed on create but not update.

I could use this ASAP. Let me know what, if anything, needs to change.