### PR TITLE
Sensible error message when plan's currency doesn't match user's urrency

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -100,7 +100,7 @@ module StripeMock
 
         if plan && customer
           unless customer[:currency].to_s == plan[:currency].to_s
-            raise Stripe::InvalidRequestError.new('lol', 'currency', http_status: 400)
+            raise Stripe::InvalidRequestError.new("Customer's currency of #{customer[:currency]} does not match plan's currency of #{plan[:currency]}", 'currency', http_status: 400)
           end
         end
 


### PR DESCRIPTION
Having my tests fail with `(Status 400) lol` was confusing for me.