### PR TITLE
Change card to source in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ describe MyApp do
     # Specify :source in place of :card (with same value) to return customer with source data
     customer = Stripe::Customer.create({
       email: 'johnny@appleseed.com',
-      card: stripe_helper.generate_card_token
+      source: stripe_helper.generate_card_token
     })
     expect(customer.email).to eq('johnny@appleseed.com')
   end


### PR DESCRIPTION
`card` doesn't work with token anymore with Stripe API and here as well

[Here's is the link to source](https://stripe.com/docs/api#create_customer-source)