### PR TITLE
Support updating subscription with multiple plan items

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -40,7 +40,7 @@ module StripeMock
           end
 
           subscription = Data.mock_subscription({ id: new_id('su') })
-          subscription.merge!(custom_subscription_params(plan, customers[ params[:id] ], params))
+          subscription = resolve_subscription_changes(subscription, [plan], customers[ params[:id] ], params)
           add_subscription_to_customer(customers[ params[:id] ], subscription)
           subscriptions[subscription[:id]] = subscription
         elsif params[:trial_end]

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -87,7 +87,7 @@ module StripeMock
           invoice_date = Time.now.to_i
           subscription_plan = assert_existence :plan, subscription_plan_id, plans[subscription_plan_id.to_s]
           preview_subscription = Data.mock_subscription
-          preview_subscription.merge!(custom_subscription_params(subscription_plan, customer, { trial_end: params[:subscription_trial_end] }))
+          preview_subscription = resolve_subscription_changes(preview_subscription, [subscription_plan], customer, { trial_end: params[:subscription_trial_end] })
           preview_subscription[:id] = subscription[:id]
           preview_subscription[:quantity] = subscription_quantity
           subscription_proration_date = params[:subscription_proration_date] || Time.now


### PR DESCRIPTION
This change allows subscriptions to be updated with multiple plan items (see [Multiple Plans per Subscription](https://stripe.com/docs/subscriptions/multiplan)). The existing code only grabs the first plan it finds in `subscription[:items]`. This fix correctly reads all plan_ids from the request params. 

Should fix https://github.com/rebelidealist/stripe-ruby-mock/issues/514