### PR TITLE
Changes BalanceTransaction source from card object to charge id

### DIFF
--- a/lib/stripe_mock/request_handlers/charges.rb
+++ b/lib/stripe_mock/request_handlers/charges.rb
@@ -41,7 +41,7 @@ module StripeMock
         end
 
         ensure_required_params(params)
-        bal_trans_params = { amount: params[:amount], source: params[:source] }
+        bal_trans_params = { amount: params[:amount], source: id }
 
         balance_transaction_id = new_balance_transaction('txn', bal_trans_params)
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -171,7 +171,7 @@ shared_examples 'Charge API' do
     bal_trans = Stripe::BalanceTransaction.retrieve(charge.balance_transaction)
     expect(bal_trans.amount).to eq(charge.amount)
     expect(bal_trans.fee).to eq(39)
-    expect(bal_trans.source).to eq(charge.source)
+    expect(bal_trans.source).to eq(charge.id)
   end
 
   context 'when conversion rate is set' do


### PR DESCRIPTION
It seems like the BalanceTransaction source should be the charge id, not the card object.