### PR TITLE
Assign a generated ID to plans when no ID is specified

### DIFF
--- a/lib/stripe_mock/request_handlers/plans.rb
+++ b/lib/stripe_mock/request_handlers/plans.rb
@@ -11,6 +11,7 @@ module StripeMock
       end
 
       def new_plan(route, method_url, params, headers)
+        params[:id] ||= new_id('plan')
         validate_create_plan_params(params)
         plans[ params[:id] ] = Data.mock_plan(params)
       end

--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -30,6 +30,17 @@ shared_examples 'Plan API' do
   end
 
 
+  it "creates a stripe plan without specifying ID" do
+    plan = Stripe::Plan.create(
+      :name => 'The Mock Plan',
+      :amount => 9900,
+      :currency => 'USD',
+      :interval => 1,
+    )
+
+    expect(plan.id).to match(/^test_plan/)
+  end
+
   it "stores a created stripe plan in memory" do
     plan = Stripe::Plan.create(
       :id => 'pid_2',


### PR DESCRIPTION
Somewhere between [2017-04-03](https://web.archive.org/web/20170403170607/https://stripe.com/docs/api#create_plan) and [2017-04-10](https://web.archive.org/web/20170410171400/https://stripe.com/docs/api#create_plan) Stripe changed from the ID being required to the ID being optional, in which case Stripe would generate the ID automatically.

Previously, stripe-ruby-mock would cast the ID to a string to perform validations, so without an ID, a blank string would be assigned as an ID, which then errored if you tried to create a second plan without an ID as a plan with the same ID (blank string) already existed.

Now, a generated ID will be assigned when no ID is provided.