### PR TITLE
Support billing_cycle_anchor on subscriptions

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -26,11 +26,11 @@ module StripeMock
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"
-          end_time = get_ending_time(start_time, plan)
-          params.merge!({status: 'active', current_period_end: end_time, trial_start: nil, trial_end: nil})
+          end_time = options[:billing_cycle_anchor] || get_ending_time(start_time, plan)
+          params.merge!({status: 'active', current_period_end: end_time, trial_start: nil, trial_end: nil, billing_cycle_anchor: options[:billing_cycle_anchor]})
         else
           end_time = options[:trial_end] || (Time.now.utc.to_i + plan[:trial_period_days]*86400)
-          params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time})
+          params.merge!({status: 'trialing', current_period_end: end_time, trial_start: start_time, trial_end: end_time, billing_cycle_anchor: nil})
         end
 
         params

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -95,7 +95,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -283,6 +283,7 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.object).to eq('subscription')
       expect(sub.plan.to_hash).to eq(plan.to_hash)
       expect(sub.trial_end - sub.trial_start).to eq(14 * 86400)
+      expect(sub.billing_cycle_anchor).to be_nil
 
       customer = Stripe::Customer.retrieve('cardless')
       expect(customer.subscriptions.data).to_not be_empty
@@ -396,6 +397,18 @@ shared_examples 'Customer Subscriptions' do
         expect(e.http_status).to eq(400)
         expect(e.message).to eq("Invalid timestamp: can be no more than five years in the future")
       }
+    end
+
+    it 'overrides current period end when billing cycle anchor is set' do
+      plan = stripe_helper.create_plan(id: 'plan', amount: 999)
+      customer = Stripe::Customer.create(source: gen_card_tk)
+      billing_cycle_anchor = Time.now.utc.to_i + 3600
+
+      sub = Stripe::Subscription.create({ plan: 'plan', customer: customer.id, billing_cycle_anchor: billing_cycle_anchor })
+
+      expect(sub.status).to eq('active')
+      expect(sub.current_period_end).to eq(billing_cycle_anchor)
+      expect(sub.billing_cycle_anchor).to eq(billing_cycle_anchor)
     end
 
     it 'when plan defined inside items', live: true do


### PR DESCRIPTION
This allows indicating when the first full payment should be charged.

It was documented starting in API version [2018-02-05](https://stripe.com/docs/upgrades#2018-02-05), but is available retroactively on past versions.

When set, the current period ends at the given time, before a new, full period starts.

Technically it can be combined with trials, but I'm not as familiar with that side, so I didn't attempt to implement it for fear of implementing it wrong.