### PR TITLE
The 'time' library must be explicitly required for 'to_datetime'

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 require 'multi_json'
 require 'dante'
+require 'time'
 
 require 'stripe'
 


### PR DESCRIPTION
to_datetime is currently being used in subscription_helpers.rb and the specs. Because it isn't required, the specs fail for me. I'm guessing a gem included it as a side-effect previously, but that's no longer the case.