### PR TITLE
Allow overwriting of the default currency

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -74,11 +74,13 @@ require 'stripe_mock/test_strategies/live.rb'
 
 module StripeMock
 
+  @default_currency = 'usd'
   lib_dir = File.expand_path(File.dirname(__FILE__), '../..')
   @webhook_fixture_path = './spec/fixtures/stripe_webhooks/'
   @webhook_fixture_fallback_path = File.join(lib_dir, 'stripe_mock/webhook_fixtures')
 
   class << self
+    attr_accessor :default_currency
     attr_accessor :webhook_fixture_path
   end
 end

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -3,7 +3,7 @@ module StripeMock
 
     def self.mock_account(params = {})
       id = params[:id] || 'acct_103ED82ePvKYlo2C'
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: id,
         email: "bob@example.com",
@@ -103,7 +103,8 @@ module StripeMock
 
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
-      currency = params[:currency] || 'usd'
+      puts @default_currency
+      currency = params[:currency] || StripeMock.default_currency
       sources.each {|source| source[:customer] = cus_id}
       {
         email: 'stripe_mock@example.com',
@@ -134,7 +135,7 @@ module StripeMock
 
     def self.mock_charge(params={})
       charge_id = params[:id] || "ch_1fD6uiR9FAA2zc"
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: charge_id,
         object: "charge",
@@ -196,7 +197,7 @@ module StripeMock
     end
 
     def self.mock_refund(params={})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: "re_4fWhgUh5si7InF",
         amount: 1,
@@ -248,7 +249,7 @@ module StripeMock
     end
 
     def self.mock_bank_account(params={})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: "test_ba_default",
         object: "bank_account",
@@ -306,7 +307,7 @@ module StripeMock
             plan: {
               amount: 999,
               created: 1504035972,
-              currency: 'usd'
+              currency: StripeMock.default_currency
             },
             quantity: 1
           }]
@@ -328,7 +329,7 @@ module StripeMock
 
     def self.mock_invoice(lines, params={})
       in_id = params[:id] || "test_in_default"
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       lines << Data.mock_line_item() if lines.empty?
       invoice = {
         id: 'in_test_invoice',
@@ -379,7 +380,7 @@ module StripeMock
     end
 
     def self.mock_line_item(params = {})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: "ii_test",
         object: "line_item",
@@ -402,7 +403,7 @@ module StripeMock
     end
 
     def self.mock_invoice_item(params = {})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: "test_ii",
         object: "invoiceitem",
@@ -490,7 +491,7 @@ module StripeMock
     end
 
     def self.mock_plan(params={})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       {
         id: "2",
         object: "plan",
@@ -591,7 +592,7 @@ module StripeMock
     end
 
     def self.mock_transfer(params={})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       id = params[:id] || 'tr_test_transfer'
       {
         :status => 'pending',
@@ -623,7 +624,7 @@ module StripeMock
     end
 
     def self.mock_payout(params={})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       id = params[:id] || 'po_test_payout'
       {
         :amount => 100,
@@ -647,7 +648,7 @@ module StripeMock
 
     def self.mock_dispute(params={})
       @timestamp ||= Time.now.to_i
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       id = params[:id] || "dp_test_dispute"
       {
         :id => id,
@@ -967,7 +968,7 @@ module StripeMock
     end
 
     def self.mock_balance_transaction(params = {})
-      currency = params[:currency] || 'usd'
+      currency = params[:currency] || StripeMock.default_currency
       bt_id = params[:id] || 'test_txn_default'
       source = params[:source] || 'ch_test_charge'
       {
@@ -1015,7 +1016,7 @@ module StripeMock
           object: 'plan',
           amount: 1337,
           created: 1504716177,
-          currency: 'usd',
+          currency: StripeMock.default_currency,
           interval: 'month',
           interval_count: 1,
           livemode: false,

--- a/lib/stripe_mock/request_handlers/invoices.rb
+++ b/lib/stripe_mock/request_handlers/invoices.rb
@@ -166,9 +166,9 @@ module StripeMock
       #anonymous charge
       def invoice_charge(invoice)
         begin
-          new_charge(nil, nil, {customer: invoice[:customer]["id"], amount: invoice[:amount_due], currency: 'usd'}, nil)
+          new_charge(nil, nil, {customer: invoice[:customer]["id"], amount: invoice[:amount_due], currency: StripeMock.default_currency}, nil)
         rescue Stripe::InvalidRequestError
-          new_charge(nil, nil, {source: generate_card_token, amount: invoice[:amount_due], currency: 'usd'}, nil)
+          new_charge(nil, nil, {source: generate_card_token, amount: invoice[:amount_due], currency: StripeMock.default_currency}, nil)
         end
       end
 

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -3,7 +3,7 @@ module StripeMock
     class Base
 
       def create_plan_params(params={})
-        currency = params[:currency] || 'usd'
+        currency = params[:currency] || StripeMock.default_currency
         {
           :id => 'stripe_mock_default_plan_id',
           :name => 'StripeMock Default Plan ID',
@@ -23,7 +23,7 @@ module StripeMock
       end
 
       def generate_bank_token(bank_account_params={})
-        currency = bank_account_params[:currency] || 'usd'
+        currency = bank_account_params[:currency] || StripeMock.default_currency
         bank_account = {
           :country => "US",
           :currency => currency,
@@ -39,7 +39,7 @@ module StripeMock
       end
 
       def create_coupon_params(params = {})
-        currency = params[:currency] || 'usd'
+        currency = params[:currency] || StripeMock.default_currency
         {
           id: '10BUCKS',
           amount_off: 1000,

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -52,4 +52,18 @@ describe StripeMock::Instance do
     StripeMock.set_conversion_rate(1.25)
     expect(StripeMock.instance.conversion_rate).to eq(1.25)
   end
+
+  it "allows non-usd default currency" do
+    old_default_currency = StripeMock.default_currency
+    customer = begin
+      StripeMock.default_currency = "jpy"
+      Stripe::Customer.create({
+        email: 'johnny@appleseed.com',
+        source: stripe_helper.generate_card_token
+      })
+    ensure
+      StripeMock.default_currency = old_default_currency
+    end
+    expect(customer.currency).to eq("jpy")
+  end
 end


### PR DESCRIPTION
In my application, when we create customers, we aren't specifying the currency. Stripe's documentation for "Create a customer" doesn't state that you can specify a currency, so I'm guessing that it is somehow inferred.

As my application does not use USD, the check for matching currencies that was added in 0bb51d14e3668d4b026bd4de6c810a402ab90252 broke my tests.

Allowing to specify a default currency other than usd seemed like the most straightforward approach to get this working.

I couldn't figure out a good approach to get it to work for the server spec, as I can't easily overwrite the default for the server (as the server is started once before all the specs). It should still work though even if you are using the server. Due to my change having little chance of introducing a regression, I decided to only make a spec for the instance version.