### PR TITLE
Respect subscription item plan quantity option when creating multi-plan subscriptions

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -8,7 +8,15 @@ module StripeMock
 
       def resolve_subscription_changes(subscription, plans, customer, options = {})
         subscription.merge!(custom_subscription_params(plans, customer, options))
-        subscription[:items][:data] = plans.map { |plan| Data.mock_subscription_item({ plan: plan }) }
+        subscription[:items][:data] = plans.map do |plan|
+          if options[:items] && options[:items].size == plans.size
+            quantity = options[:items] &&
+              options[:items].values.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
+            Data.mock_subscription_item({ plan: plan, quantity: quantity })
+          else
+            Data.mock_subscription_item({ plan: plan })
+          end
+        end
         subscription
       end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -436,6 +436,8 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.plan).to eq nil
       expect(subscription.items.data[0].plan.id).to eq plan.id
       expect(subscription.items.data[1].plan.id).to eq plan2.id
+      expect(subscription.items.data[0].quantity).to eq 1
+      expect(subscription.items.data[1].quantity).to eq 2
     end
 
     it 'when plan defined inside items for trials with no card', live: true do


### PR DESCRIPTION
Support for creating `Subscriptions` with multiple `Plans` via `SubscriptionItems` was introduced in https://github.com/rebelidealist/stripe-ruby-mock/pull/469/ to work like so:

```ruby
subscription = Stripe::Subscription.create(
  customer: customer.id,
  items: [
    { plan: plan.id, quantity: 1 },
    { plan: plan2.id, quantity: 2 }
  ]
)
```
However [the specs introduced with that change](https://github.com/rebelidealist/stripe-ruby-mock/pull/469/files#diff-4927653ddd5cec02e1cb190b37ac73caR331) do not check that the `quantity` option is correctly mocked for the subscription items.

This PR adds the missing spec expectations and takes a stab at fixing the issue.

## Caveats

My knowledge of the codebase and its data structures is limited, and so the code might be more complicated than it needs to be. I tried to infer what the `options` hash should contain based on the number of plans per subscription. Any feedback is welcome.

