### PR TITLE
added dynamically generated exp_year

### DIFF
--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -16,7 +16,7 @@ module StripeMock
       end
 
       def generate_card_token(card_params={})
-        card_data = { :number => "4242424242424242", :exp_month => 9, :exp_year => 2018, :cvc => "999", :tokenization_method => nil }
+        card_data = { :number => "4242424242424242", :exp_month => 9, :exp_year => Time.now.year+1, :cvc => "999", :tokenization_method => nil }
         card = StripeMock::Util.card_merge(card_data, card_params)
         card[:fingerprint] = StripeMock::Util.fingerprint(card[:number]) if StripeMock.state == 'local'
 


### PR DESCRIPTION
My test was failed after Oct 2018 is reached. Updated to fix this.