### PR TITLE
improved Data#mock_subscription_item to return real quantity and deleted status

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1,6 +1,5 @@
 module StripeMock
   module Data
-
     def self.mock_account(params = {})
       id = params[:id] || 'acct_103ED82ePvKYlo2C'
       currency = params[:currency] || StripeMock.default_currency
@@ -1001,6 +1000,8 @@ module StripeMock
     end
 
     def self.mock_subscription_item(params = {})
+      item_options = params[:item_options]
+
       iid = params[:id] || 'test_txn_default'
       {
         id: iid,
@@ -1022,7 +1023,8 @@ module StripeMock
           statement_descriptor: nil,
           trial_period_days: nil
         },
-        quantity: 2
+        quantity: (item_options[:quantity] || 1),
+        deleted: (item_options[:deleted] || false)
       }.merge(params)
     end
 

--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -7,8 +7,13 @@ module StripeMock
       end
 
       def resolve_subscription_changes(subscription, plans, customer, options = {})
-        subscription.merge!(custom_subscription_params(plans, customer, options))
-        subscription[:items][:data] = plans.map { |plan| Data.mock_subscription_item({ plan: plan }) }
+        items_arr = options[:items_arr] || []
+
+        subscription.merge!(custom_subscription_params(plans, customer, options.except(:items_arr)))
+        subscription[:items][:data] = plans.map do |plan|
+          item_options = items_arr.find { |item| item[:plan] == plan[:id] } || {}
+          Data.mock_subscription_item({ plan: plan, item_options: item_options })
+        end
         subscription
       end
 

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -45,6 +45,7 @@ module StripeMock
         end
 
         subscription = Data.mock_subscription({ id: (params[:id] || new_id('su')) })
+        # TODO: mock quantity and deleted here
         subscription = resolve_subscription_changes(subscription, subscription_plans, customer, params)
 
         # Ensure customer has card to charge if plan has no trial and is not free
@@ -189,7 +190,8 @@ module StripeMock
         end
 
         params[:current_period_start] = subscription[:current_period_start]
-        subscription = resolve_subscription_changes(subscription, subscription_plans, customer, params)
+        items_arr = params[:items].values
+        subscription = resolve_subscription_changes(subscription, subscription_plans, customer, items_arr: items_arr)
 
         # delete the old subscription, replace with the new subscription
         customer[:subscriptions][:data].reject! { |sub| sub[:id] == subscription[:id] }


### PR DESCRIPTION
Allow users to mock quantity and deleted status for Subscription items.