### PR TITLE
Fix subscription creation

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -11,7 +11,7 @@ module StripeMock
         subscription[:items][:data] = plans.map do |plan|
           if options[:items] && options[:items].size == plans.size
             quantity = options[:items] &&
-              options[:items].values.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
+              options[:items].detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
             Data.mock_subscription_item({ plan: plan, quantity: quantity })
           else
             Data.mock_subscription_item({ plan: plan })


### PR DESCRIPTION
First reported in #563 and discovered independently while upgrading to 2.5.5.

#547 introduced this regression. No idea why the tests didn't fail from that PR, but [the build from that merge](https://travis-ci.org/rebelidealist/stripe-ruby-mock/jobs/420077462) clearly shows that change breaking tests that weren't broken in [the previous build](https://travis-ci.org/rebelidealist/stripe-ruby-mock/jobs/410656163).

This PR causes the tests to pass for me locally, and fixes my tests that used this code.