### PR TITLE
Update tests to account for product -> plan

### DIFF
--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -5,7 +5,9 @@ shared_examples 'Plan API' do
   it "creates a stripe plan" do
     plan = Stripe::Plan.create(
       :id => 'pid_1',
-      :name => 'The Mock Plan',
+      :product => {
+        :name => 'The Mock Plan'
+      },
       :amount => 9900,
       :currency => 'USD',
       :interval => 1,
@@ -17,7 +19,7 @@ shared_examples 'Plan API' do
     )
 
     expect(plan.id).to eq('pid_1')
-    expect(plan.name).to eq('The Mock Plan')
+    expect(plan.product.name).to eq('The Mock Plan')
     expect(plan.amount).to eq(9900)
 
     expect(plan.currency).to eq('USD')
@@ -32,7 +34,9 @@ shared_examples 'Plan API' do
 
   it "creates a stripe plan without specifying ID" do
     plan = Stripe::Plan.create(
-      :name => 'The Mock Plan',
+      :product => {
+        :name => 'The Mock Plan'
+      },
       :amount => 9900,
       :currency => 'USD',
       :interval => 1,
@@ -44,14 +48,18 @@ shared_examples 'Plan API' do
   it "stores a created stripe plan in memory" do
     plan = Stripe::Plan.create(
       :id => 'pid_2',
-      :name => 'The Memory Plan',
+      :product => {
+        :name => 'The Memory Plan'
+      },
       :amount => 1100,
       :currency => 'USD',
       :interval => 1
     )
     plan2 = Stripe::Plan.create(
       :id => 'pid_3',
-      :name => 'The Bonk Plan',
+      :product => {
+        :name => 'The Bonk Plan'
+      },
       :amount => 7777,
       :currency => 'USD',
       :interval => 1
@@ -133,7 +141,9 @@ shared_examples 'Plan API' do
     expect {
       Stripe::Plan.create(
         :id => 'pid_1',
-        :name => 'The Mock Plan',
+        :product => {
+          :name => 'StripeMock Default Plan ID'
+        },
         :amount => 99.99,
         :currency => 'USD',
         :interval => 'month'
@@ -157,7 +167,7 @@ shared_examples 'Plan API' do
         expect { subject }.to raise_error(Stripe::InvalidRequestError, message)
       end
 
-      it("requires a name") { @name = :name }
+      it("requires a product") { @name = :product }
       it("requires an amount") { @name = :amount }
       it("requires a currency") { @name = :currency }
       it("requires an interval") { @name = :interval }

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -163,6 +163,7 @@ shared_examples 'Customer Subscriptions' do
         :product => {
           :name => 'Test plan'
         },
+        :name => 'Test Plan',
         :currency => 'usd',
         :id => 'silver',
         :statement_description => "testPlan"


### PR DESCRIPTION
Stripe's recent API changes require a `product` param that includes the
plan product name, rather than a bare `name` param. Updating tests to
match this expection should get everything green in CI.