### PR TITLE
Add params billing and days_until_due

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -30,7 +30,8 @@ module StripeMock
         start_time = options[:current_period_start] || now
         params = { customer: cus[:id], current_period_start: start_time, created: created_time }
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
-        params.merge! options.select {|k,v| k =~ /application_fee_percent|quantity|metadata|tax_percent/}
+        keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due/
+        params.merge! options.select {|k,v| k =~ keys_to_merge}
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -95,7 +95,7 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor)
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -472,6 +472,28 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.items.data[0].plan.id).to eq plan.id
       expect(subscription.items.data[1].plan.id).to eq plan2.id
     end
+
+    it 'add a new subscription to bill via an invoice' do
+      plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
+                                       amount: 4999, currency: 'usd')
+      customer = Stripe::Customer.create(source: gen_card_tk)
+
+      expect(customer.subscriptions.data).to be_empty
+      expect(customer.subscriptions.count).to eq(0)
+
+      sub = Stripe::Subscription.create({
+        plan: 'silver',
+        customer: customer.id,
+        metadata: { foo: 'bar', example: 'yes' },
+        billing: 'send_invoice',
+        days_until_due: 30,
+      })
+
+      expect(sub.object).to eq('subscription')
+      expect(sub.plan.to_hash).to eq(plan.to_hash)
+      expect(sub.billing).to eq 'send_invoice'
+      expect(sub.days_until_due).to eq 30
+    end
   end
 
   context "updating a subscription" do


### PR DESCRIPTION
Issue #582
Add support for these params:
https://stripe.com/docs/api/subscriptions/create#create_subscription-billing
https://stripe.com/docs/api/subscriptions/create#create_subscription-days_until_due