### PR TITLE
Subscription with send_invoice doesn't need card

### DIFF
--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -476,7 +476,7 @@ shared_examples 'Customer Subscriptions' do
     it 'add a new subscription to bill via an invoice' do
       plan = stripe_helper.create_plan(id: 'silver', product: { name: 'Silver Plan' },
                                        amount: 4999, currency: 'usd')
-      customer = Stripe::Customer.create(source: gen_card_tk)
+      customer = Stripe::Customer.create(id: 'cardless')
 
       expect(customer.subscriptions.data).to be_empty
       expect(customer.subscriptions.count).to eq(0)


### PR DESCRIPTION
* refactored some of the code for verifying whether card was present
* if subscription has billing set to `send_invoice`, we don't need a card.