### PR TITLE
Rename transfer webhooks to payout

### DIFF
--- a/lib/stripe_mock/api/webhooks.rb
+++ b/lib/stripe_mock/api/webhooks.rb
@@ -75,10 +75,10 @@ module StripeMock
         'plan.deleted',
         'coupon.created',
         'coupon.deleted',
-        'transfer.created',
-        'transfer.paid',
-        'transfer.updated',
-        'transfer.failed'
+        'payout.created',
+        'payout.paid',
+        'payout.updated',
+        'payout.failed'
       ]
     end
   end

--- a/lib/stripe_mock/webhook_fixtures/payout.created.json
+++ b/lib/stripe_mock/webhook_fixtures/payout.created.json
@@ -2,7 +2,7 @@
   "created": 1326853478,
   "livemode": false,
   "id": "evt_00000000000000",
-  "type": "transfer.updated",
+  "type": "payout.created",
   "object": "event",
   "data": {
     "object": {
@@ -84,9 +84,6 @@
       },
       "statement_descriptor": null,
       "recipient": null
-    },
-    "previous_attributes": {
-      "amount": 123
     }
   }
 }

--- a/lib/stripe_mock/webhook_fixtures/payout.failed.json
+++ b/lib/stripe_mock/webhook_fixtures/payout.failed.json
@@ -2,7 +2,7 @@
   "created": 1326853478,
   "livemode": false,
   "id": "evt_00000000000000",
-  "type": "transfer.created",
+  "type": "payout.failed",
   "object": "event",
   "data": {
     "object": {
@@ -12,7 +12,7 @@
       "livemode": false,
       "amount": 67,
       "currency": "usd",
-      "status": "pending",
+      "status": "failed",
       "balance_transaction": "txn_00000000000000",
       "summary": {
         "charge_gross": 100,

--- a/lib/stripe_mock/webhook_fixtures/payout.paid.json
+++ b/lib/stripe_mock/webhook_fixtures/payout.paid.json
@@ -2,7 +2,7 @@
   "created": 1326853478,
   "livemode": false,
   "id": "evt_00000000000000",
-  "type": "transfer.failed",
+  "type": "payout.paid",
   "object": "event",
   "data": {
     "object": {
@@ -12,7 +12,7 @@
       "livemode": false,
       "amount": 67,
       "currency": "usd",
-      "status": "failed",
+      "status": "paid",
       "balance_transaction": "txn_00000000000000",
       "summary": {
         "charge_gross": 100,

--- a/lib/stripe_mock/webhook_fixtures/payout.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/payout.updated.json
@@ -2,7 +2,7 @@
   "created": 1326853478,
   "livemode": false,
   "id": "evt_00000000000000",
-  "type": "transfer.paid",
+  "type": "payout.updated",
   "object": "event",
   "data": {
     "object": {
@@ -12,7 +12,7 @@
       "livemode": false,
       "amount": 67,
       "currency": "usd",
-      "status": "paid",
+      "status": "pending",
       "balance_transaction": "txn_00000000000000",
       "summary": {
         "charge_gross": 100,
@@ -84,6 +84,9 @@
       },
       "statement_descriptor": null,
       "recipient": null
+    },
+    "previous_attributes": {
+      "amount": 123
     }
   }
 }


### PR DESCRIPTION
There were renamed by Stripe last year.