### PR TITLE
Subscription Creation with multiple plan identifiers

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -10,6 +10,7 @@ module StripeMock
         subscription.merge!(custom_subscription_params(plans, customer, options))
         subscription[:items][:data] = plans.map do |plan|
           if options[:items] && options[:items].size == plans.size
+            options[:items] = options[:items].values if options[:items].respond_to?(:values)
             quantity = options[:items] &&
               options[:items].detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
             Data.mock_subscription_item({ plan: plan, quantity: quantity })


### PR DESCRIPTION
This PR fixes the `TypeError (no implicit conversion of Symbol into Integer)` error, raised when adding multiple plan identifiers in `Stripe::Subscription.create` method.

```ruby
Stripe::Subscription.create(customer: customer.id, items: [{ plan: 'my_plan'}])
# => TypeError (no implicit conversion of Symbol into Integer)
```