### PR TITLE
support cancelling at period end by updating the subscription

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -32,6 +32,13 @@ module StripeMock
         params.merge!({ :plan => (plans.size == 1 ? plans.first : nil) })
         keys_to_merge = /application_fee_percent|quantity|metadata|tax_percent|billing|days_until_due/
         params.merge! options.select {|k,v| k =~ keys_to_merge}
+
+        if options[:cancel_at_period_end] == true
+          params.merge!(cancel_at_period_end: true, canceled_at: now)
+        elsif options[:cancel_at_period_end] == false
+          params.merge!(cancel_at_period_end: false, canceled_at: nil)
+        end
+
         # TODO: Implement coupon logic
 
         if (((plan && plan[:trial_period_days]) || 0) == 0 && options[:trial_end].nil?) || options[:trial_end] == "now"

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -913,6 +913,52 @@ shared_examples 'Customer Subscriptions' do
     end
   end
 
+  it "supports 'cancelling' by updating cancel_at_period_end" do
+    truth = stripe_helper.create_plan(id: 'the_truth')
+    customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "the_truth")
+
+    sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+    result = Stripe::Subscription.update(sub.id, cancel_at_period_end: true)
+
+    expect(result.status).to eq('active')
+    expect(result.cancel_at_period_end).to eq(true)
+    expect(result.id).to eq(sub.id)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.subscriptions.data).to_not be_empty
+    expect(customer.subscriptions.count).to eq(1)
+    expect(customer.subscriptions.data.length).to eq(1)
+
+    expect(customer.subscriptions.data.first.status).to eq('active')
+    expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(true)
+    expect(customer.subscriptions.data.first.ended_at).to be_nil
+    expect(customer.subscriptions.data.first.canceled_at).to_not be_nil
+  end
+
+  it "resumes a subscription cancelled by updating cancel_at_period_end" do
+    truth = stripe_helper.create_plan(id: 'the_truth')
+    customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "the_truth")
+
+    sub = Stripe::Subscription.retrieve(customer.subscriptions.data.first.id)
+    Stripe::Subscription.update(sub.id, cancel_at_period_end: true)
+
+    result = Stripe::Subscription.update(sub.id, cancel_at_period_end: false)
+
+    expect(result.status).to eq('active')
+    expect(result.cancel_at_period_end).to eq(false)
+    expect(result.id).to eq(sub.id)
+
+    customer = Stripe::Customer.retrieve('test_customer_sub')
+    expect(customer.subscriptions.data).to_not be_empty
+    expect(customer.subscriptions.count).to eq(1)
+    expect(customer.subscriptions.data.length).to eq(1)
+
+    expect(customer.subscriptions.data.first.status).to eq('active')
+    expect(customer.subscriptions.data.first.cancel_at_period_end).to eq(false)
+    expect(customer.subscriptions.data.first.ended_at).to be_nil
+    expect(customer.subscriptions.data.first.canceled_at).to be_nil
+  end
+
   it "doesn't change status of subscription when cancelling at period end" do
     trial = stripe_helper.create_plan(id: 'trial', trial_period_days: 14)
     customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: "trial")


### PR DESCRIPTION
I think this allows for the example here (copied below): https://stripe.com/docs/billing/subscriptions/canceling-pausing. I don't think using `subscription.delete(at_period_end: true)` is supported anymore -- Stripe will throw an `InvalidRequestError`

```rb
# example from link

Stripe::Subscription.update(
  'sub_49ty4767H20z6a',
  {
    cancel_at_period_end: true,
  }
)
```