### PR TITLE
Add status field to charge.succeeded event

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/charge.succeeded.json
@@ -8,6 +8,7 @@
     "object": {
       "id": "ch_00000000000000",
       "object": "charge",
+      "status": "succeeded",
       "created": 1380933505,
       "livemode": false,
       "paid": true,


### PR DESCRIPTION
https://stripe.com/docs/api/events/object#event_object-data-object

> Object containing the API resource relevant to the event. For example, an invoice.created event will have a full invoice object as the value of the object key.