### PR TITLE
Fix the failed tests at plan_examples.rb:157

### DIFF
--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -157,7 +157,7 @@ shared_examples 'Plan API' do
         expect { subject }.to raise_error(Stripe::InvalidRequestError, message)
       end
 
-      it("requires a name") { @name = :name }
+      it("requires a product") { @name = :product }
       it("requires an amount") { @name = :amount }
       it("requires a currency") { @name = :currency }
       it("requires an interval") { @name = :interval }


### PR DESCRIPTION
### What solves

This pull request fixes two failed tests:

```
  X) StripeMock::Instance behaves like Plan API Validation Required Parameters requires a name
     Failure/Error: expect { subject }.to raise_error(Stripe::InvalidRequestError, message)
       expected Stripe::InvalidRequestError with "Missing required param: name." but nothing was raised
     Shared Example Group: "Plan API" called from ./spec/support/stripe_examples.rb:23
     # ./spec/shared_stripe_examples/plan_examples.rb:157:in `block (4 levels) in <top (required)>'

  X) StripeMock Server behaves like Plan API Validation Required Parameters requires a name
     Failure/Error: expect { subject }.to raise_error(Stripe::InvalidRequestError, message)
       expected Stripe::InvalidRequestError with "Missing required param: name." but nothing was raised
     Shared Example Group: "Plan API" called from ./spec/support/stripe_examples.rb:23
     # ./spec/shared_stripe_examples/plan_examples.rb:157:in `block (4 levels) in <top (required)>'
```

### How to solve

Those tests are testing for the lack of params to create an instance of Plan.
It seems not to use `Plan#name` param anymore, but `Plan#product[:name]` param at these days.

Stripe API Docs: https://stripe.com/docs/api/plans/create#create_plan-product
Create Plan: https://github.com/rebelidealist/stripe-ruby-mock/blob/f74d936fcfd64f9a2a95694ff21048513194a934/lib/stripe_mock/test_strategies/base.rb#L9-L11

So, we should change the test not to delete `name` param but `product[:name]`.
