### PR TITLE
Fixes Transfer API examples in live mode

### DIFF
--- a/spec/shared_stripe_examples/transfer_examples.rb
+++ b/spec/shared_stripe_examples/transfer_examples.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 shared_examples 'Transfer API' do
 
   it "creates a stripe transfer" do
-    destination = Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", id: "acct_12345")
+    destination = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", id: "acct_12345")
     transfer = Stripe::Transfer.create(amount: 100, currency: "usd", destination: destination.id)
 
     expect(transfer.id).to match /^test_tr/
@@ -31,7 +31,7 @@ shared_examples 'Transfer API' do
   end
 
   describe "listing transfers" do
-    let(:destination) { Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo") }
+    let(:destination) { Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo") }
 
     before do
       3.times do
@@ -48,7 +48,7 @@ shared_examples 'Transfer API' do
     end
 
     it "filters the search to a specific destination" do
-      d2 = Stripe::Account.create(email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo")
+      d2 = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo")
       Stripe::Transfer.create(amount: "100", currency: "usd", destination: d2.id)
 
       expect(Stripe::Transfer.all(destination: d2.id).count).to eq(1)
@@ -104,7 +104,7 @@ shared_examples 'Transfer API' do
   end
 
   it "when amount is not integer", live: true do
-    dest = Stripe::Account.create(type: "standard", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
+    dest = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
     expect { Stripe::Transfer.create(amount: '400.2',
                                      currency: 'usd',
                                      destination: dest.id,
@@ -116,7 +116,7 @@ shared_examples 'Transfer API' do
   end
 
   it "when amount is negative", live: true do
-    dest = Stripe::Account.create(type: "standard", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
+    dest = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "Alex Smith")
     expect { Stripe::Transfer.create(amount: '-400',
                                      currency: 'usd',
                                      destination: dest.id,


### PR DESCRIPTION
* Stripe only supports creating "custom" type accounts via the API
* https://stripe.com/docs/api/accounts/create#create_account-type