### PR TITLE
Fix discount related specs

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -51,7 +51,7 @@ module StripeMock
           coupon = coupons[ params[:coupon] ]
           assert_existence :coupon, params[:coupon], coupon
 
-          add_coupon_to_customer(customers[params[:id]], coupon)
+          add_coupon_to_object(customers[params[:id]], coupon)
         end
 
         customers[ params[:id] ]
@@ -90,7 +90,7 @@ module StripeMock
           coupon = coupons[ params[:coupon] ]
           assert_existence :coupon, params[:coupon], coupon
 
-          add_coupon_to_customer(cus, coupon)
+          add_coupon_to_object(cus, coupon)
         end
 
         cus

--- a/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
@@ -1,18 +1,17 @@
 module StripeMock
   module RequestHandlers
     module Helpers
+      def add_coupon_to_object(object, coupon)
+        discount_attrs = {}.tap do |attrs|
+          attrs[object[:object]]         = object[:id]
+          attrs[:coupon]                 = coupon
+          attrs[:start]                  = Time.now.to_i
+          attrs[:end]                    = (DateTime.now >> coupon[:duration_in_months].to_i).to_time.to_i if coupon[:duration] == 'repeating'
+        end
 
-      def add_coupon_to_customer(customer, coupon)
-        customer[:discount] = {
-            coupon: coupon,
-            customer: customer[:id],
-            start: Time.now.to_i,
-        }
-        customer[:discount][:end] = (DateTime.now >> coupon[:duration_in_months]).to_time.to_i  if coupon[:duration].to_sym == :repeating && coupon[:duration_in_months]
-
-        customer
+        object[:discount] = Stripe::Discount.construct_from(discount_attrs)
+        object
       end
-
     end
   end
 end

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -60,7 +60,7 @@ module StripeMock
           coupon = coupons[coupon_id]
 
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end
@@ -117,7 +117,7 @@ module StripeMock
           coupon = coupons[coupon_id]
 
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end
@@ -174,9 +174,9 @@ module StripeMock
 
           coupon = coupons[coupon_id]
           if coupon
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object({ coupon: coupon }, {})
+            add_coupon_to_object(subscription, coupon)
           elsif coupon_id == ""
-            subscription[:discount] = Stripe::Util.convert_to_stripe_object(nil, {})
+            subscription[:discount] = nil
           else
             raise Stripe::InvalidRequestError.new("No such coupon: #{coupon_id}", 'coupon', http_status: 400)
           end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -226,7 +226,7 @@ shared_examples 'Customer API' do
       discount = Stripe::Customer.retrieve(customer.id).discount
       expect(discount).to_not be_nil
       expect(discount.coupon).to_not be_nil
-      expect(discount.end).to be_within(1).of (Time.now + 365 * 24 * 3600).to_i
+      expect(discount.end).to be_within(1).of (Time.now.to_datetime >> 12).to_time.to_i
     end
     after { Stripe::Coupon.retrieve(coupon.id).delete }
     after { Stripe::Customer.retrieve(customer.id).delete }

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -140,7 +140,7 @@ shared_examples 'Customer Subscriptions' do
       expect(customer.subscriptions.data).to be_a(Array)
       expect(customer.subscriptions.data.count).to eq(1)
       expect(customer.subscriptions.data.first.discount).not_to be_nil
-      expect(customer.subscriptions.data.first.discount).to be_a(Stripe::StripeObject)
+      expect(customer.subscriptions.data.first.discount).to be_a(Stripe::Discount)
       expect(customer.subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
     end
 
@@ -614,7 +614,7 @@ shared_examples 'Customer Subscriptions' do
       subscription.save
 
       expect(subscription.discount).not_to be_nil
-      expect(subscription.discount).to be_an_instance_of(Stripe::StripeObject)
+      expect(subscription.discount).to be_a(Stripe::Discount)
       expect(subscription.discount.coupon.id).to eq(coupon.id)
     end
 


### PR DESCRIPTION
Fix discount end spec
* Calculating 12 months from now by using `Time.now + 365 * 24 * 3600`
  does not account for the upcoming leap year in 2020 and is therefore
  off by 1 day.

* Using `DateTime` to add 12 months is able to account for the leap year


Fix subscription examples when running specs in live mode
* Stripe returns an instance of `Stripe::Discount` and not a basic
  `Stripe::StripeObject`

* Additionally while here update the add_coupon helper to allow it
  to add discount/coupon to other types of objects besides customers
  and ensure that we are returning an instance of `Stripe::Discount`
  with correct parameters in all cases where we would expect Stripe
  to do so.