### PR TITLE
Adds Products resource

### DIFF
--- a/lib/stripe_mock.rb
+++ b/lib/stripe_mock.rb
@@ -70,6 +70,7 @@ require 'stripe_mock/request_handlers/subscriptions.rb'
 require 'stripe_mock/request_handlers/tokens.rb'
 require 'stripe_mock/request_handlers/country_spec.rb'
 require 'stripe_mock/request_handlers/ephemeral_key.rb'
+require 'stripe_mock/request_handlers/products.rb'
 require 'stripe_mock/instance'
 
 require 'stripe_mock/test_strategies/base.rb'

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -510,6 +510,21 @@ module StripeMock
       }.merge(params)
     end
 
+    def self.mock_product(params = {})
+      {
+        id: "default_test_prod",
+        object: "product",
+        active: true,
+        created: 1556896214,
+        livemode: false,
+        metadata: {},
+        name: "Default Test Product",
+        statement_descriptor: "PRODUCT",
+        type: "service",
+        updated: 1556918200,
+      }.merge(params)
+    end
+
     def self.mock_recipient(cards, params={})
       rp_id = params[:id] || "test_rp_default"
       cards.each {|card| card[:recipient] = rp_id}

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -36,6 +36,7 @@ module StripeMock
     include StripeMock::RequestHandlers::InvoiceItems
     include StripeMock::RequestHandlers::Orders
     include StripeMock::RequestHandlers::Plans
+    include StripeMock::RequestHandlers::Products
     include StripeMock::RequestHandlers::Refunds
     include StripeMock::RequestHandlers::Recipients
     include StripeMock::RequestHandlers::Transfers
@@ -46,7 +47,8 @@ module StripeMock
 
     attr_reader :accounts, :balance, :balance_transactions, :bank_tokens, :charges, :coupons, :customers,
                 :disputes, :events, :invoices, :invoice_items, :orders, :plans, :recipients,
-                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items
+                :refunds, :transfers, :payouts, :subscriptions, :country_spec, :subscriptions_items,
+                :products
 
     attr_accessor :error_queue, :debug, :conversion_rate, :account_balance
 
@@ -65,6 +67,7 @@ module StripeMock
       @invoice_items = {}
       @orders = {}
       @plans = {}
+      @products = {}
       @recipients = {}
       @refunds = {}
       @transfers = {}

--- a/lib/stripe_mock/request_handlers/products.rb
+++ b/lib/stripe_mock/request_handlers/products.rb
@@ -1,0 +1,43 @@
+module StripeMock
+  module RequestHandlers
+    module Products
+      def self.included(base)
+        base.add_handler 'post /v1/products',        :create_product
+        base.add_handler 'get /v1/products/(.*)',    :retrieve_product
+        base.add_handler 'post /v1/products/(.*)',   :update_product
+        base.add_handler 'get /v1/products',         :list_products
+        base.add_handler 'delete /v1/products/(.*)', :destroy_product
+      end
+
+      def create_product(_route, _method_url, params, _headers)
+        params[:id] ||= new_id('prod')
+        products[params[:id]] = Data.mock_product(params)
+      end
+
+      def retrieve_product(route, method_url, _params, _headers)
+        id = method_url.match(route).captures.first
+        assert_existence :product, id, products[id]
+      end
+
+      def update_product(route, method_url, params, _headers)
+        id = method_url.match(route).captures.first
+        product = assert_existence :product, id, products[id]
+
+        product.merge!(params)
+      end
+
+      def list_products(_route, _method_url, params, _headers)
+        limit = params[:limit] || 10
+        Data.mock_list_object(products.values.take(limit), params)
+      end
+
+      def destroy_product(route, method_url, _params, _headers)
+        id = method_url.match(route).captures.first
+        assert_existence :product, id, products[id]
+
+        products.delete(id)
+        { id: id, object: 'product', deleted: true }
+      end
+    end
+  end
+end

--- a/spec/shared_stripe_examples/product_example.rb
+++ b/spec/shared_stripe_examples/product_example.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+shared_examples 'Product API' do
+  it 'creates a product' do
+    product = Stripe::Product.create(
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    expect(product.name).to eq 'my awesome product'
+    expect(product.type).to eq 'service'
+  end
+
+  it 'retrieves a product' do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    product = Stripe::Product.retrieve('test_prod_1')
+
+    expect(product.name).to eq 'my awesome product'
+    expect(product.type).to eq 'service'
+  end
+
+  it 'updates a product' do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    Stripe::Product.update('test_prod_1', name: 'my lame product')
+
+    product = Stripe::Product.retrieve('test_prod_1')
+
+    expect(product.name).to eq 'my lame product'
+  end
+
+  it 'lists all products' do
+    2.times do |n|
+      Stripe::Product.create(
+        name: "product #{n}",
+        type: 'service'
+      )
+    end
+
+    products = Stripe::Product.list
+
+    expect(products.map(&:name)).to match_array ['product 0', 'product 1']
+  end
+
+  it 'destroys a product', live: true do
+    Stripe::Product.create(
+      id:   'test_prod_1',
+      name: 'my awesome product',
+      type: 'service'
+    )
+
+    Stripe::Product.delete('test_prod_1')
+
+    expect { Stripe::Product.retrieve('test_prod_1') }. to raise_error(Stripe::InvalidRequestError)
+  end
+end

--- a/spec/support/stripe_examples.rb
+++ b/spec/support/stripe_examples.rb
@@ -1,4 +1,3 @@
-
 def require_stripe_examples
   Dir["./spec/shared_stripe_examples/**/*.rb"].each {|f| require f}
   Dir["./spec/integration_examples/**/*.rb"].each {|f| require f}
@@ -21,6 +20,7 @@ def it_behaves_like_stripe(&block)
   it_behaves_like 'Invoice API', &block
   it_behaves_like 'Invoice Item API', &block
   it_behaves_like 'Plan API', &block
+  it_behaves_like 'Product API', &block
   it_behaves_like 'Recipient API', &block
   it_behaves_like 'Refund API', &block
   it_behaves_like 'Transfer API', &block


### PR DESCRIPTION
Pricing plans now require a product which is sort of like a bucket for plans. Products have full CRUD functionality via the API so implementing this seems like a good first step toward getting Plans on track with the Stripe API