### PR TITLE
Allow `items` parameter to be a hash

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/subscription_helpers.rb
@@ -8,10 +8,12 @@ module StripeMock
 
       def resolve_subscription_changes(subscription, plans, customer, options = {})
         subscription.merge!(custom_subscription_params(plans, customer, options))
+        items = options[:items]
+        items = items.values if items.respond_to?(:values)
         subscription[:items][:data] = plans.map do |plan|
-          if options[:items] && options[:items].size == plans.size
-            quantity = options[:items] &&
-              options[:items].detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
+          if items && items.size == plans.size
+            quantity = items &&
+              items.detect { |item| item[:plan] == plan[:id] }[:quantity] || 1
             Data.mock_subscription_item({ plan: plan, quantity: quantity })
           else
             Data.mock_subscription_item({ plan: plan })

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -552,6 +552,19 @@ shared_examples 'Customer Subscriptions' do
       sub2 = Stripe::Subscription.create({ items: [{ plan: 'silver' }], customer: customer.id }, another_subscription_header)
       expect(sub1).not_to eq(sub2)
     end
+
+    it "accepts a hash of items" do
+      silver = stripe_helper.create_plan(id: 'silver')
+      customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk)
+
+      sub = Stripe::Subscription.create({ items: { '0' => { plan: 'silver' } }, customer: customer.id })
+      sub.delete(at_period_end: true)
+
+      expect(sub.cancel_at_period_end).to be_truthy
+      expect(sub.save).to be_truthy
+      expect(sub.cancel_at_period_end).to be_falsey
+    end
+
   end
 
   context "updating a subscription" do


### PR DESCRIPTION
At least some versions of the stripe gem (see https://github.com/stripe/stripe-ruby/blob/v3.9.1/lib/stripe/subscription.rb#L18) convert the `items` parameter to a hash, and `resolve_subscription_changes` was not handling this correctly.