### PR TITLE
API upgrade: fix Plan and Invoice examples

### DIFF
--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -79,7 +79,7 @@ shared_examples 'Invoice API' do
     end
 
     it 'updates attempted and paid flags' do
-      @invoice.pay
+      @invoice = @invoice.pay
       expect(@invoice.attempted).to eq(true)
       expect(@invoice.paid).to eq(true)
     end
@@ -89,7 +89,7 @@ shared_examples 'Invoice API' do
     end
 
     it 'sets the charge attribute' do
-      @invoice.pay
+      @invoice = @invoice.pay
       expect(@invoice.charge).to be_a String
       expect(@invoice.charge.length).to be > 0
     end

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -52,7 +52,7 @@ shared_examples 'Invoice API' do
     end
 
     it "stores all invoices in memory" do
-      expect(Stripe::Invoice.all.map(&:id)).to eq([@invoice.id, @invoice2.id])
+      expect(Stripe::Invoice.all.map(&:id).sort).to eq([@invoice.id, @invoice2.id].sort)
     end
 
     it "defaults count to 10 invoices" do

--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -9,6 +9,9 @@ shared_examples 'Plan API' do
       :amount => 9900,
       :currency => 'USD',
       :interval => 1,
+      :product => {
+        :name => 'A product'
+      },
       :metadata => {
         :description => "desc text",
         :info => "info text"
@@ -36,6 +39,9 @@ shared_examples 'Plan API' do
       :amount => 9900,
       :currency => 'USD',
       :interval => 1,
+      :product => {
+        :name => 'A product'
+      }
     )
 
     expect(plan.id).to match(/^test_plan/)
@@ -47,14 +53,20 @@ shared_examples 'Plan API' do
       :name => 'The Memory Plan',
       :amount => 1100,
       :currency => 'USD',
-      :interval => 1
+      :interval => 1,
+      :product => {
+        :name => 'A product'
+      }
     )
     plan2 = Stripe::Plan.create(
       :id => 'pid_3',
       :name => 'The Bonk Plan',
       :amount => 7777,
       :currency => 'USD',
-      :interval => 1
+      :interval => 1,
+      :product => {
+        :name => 'A product'
+      }
     )
     data = test_data_source(:plans)
     expect(data[plan.id]).to_not be_nil
@@ -136,7 +148,10 @@ shared_examples 'Plan API' do
         :name => 'The Mock Plan',
         :amount => 99.99,
         :currency => 'USD',
-        :interval => 'month'
+        :interval => 'month',
+        :product => {
+          :name => 'A product'
+        }
       )
     }.to raise_error(Stripe::InvalidRequestError, "Invalid integer: 99.99")
   end


### PR DESCRIPTION
Some tests are broken on the latest API version (Issue #609)

This fixes these issues:
- mandatory `product` parameter is added for `Plan` creation
- `Invoice` object is properly refreshed after a payment
- minor fix on an array comparison that would fail randomly because of the order of elements