### PR TITLE
Update invoice fixtures to current api (2019-05-16)

### DIFF
--- a/lib/stripe_mock/webhook_fixtures/invoice.created.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.created.json
@@ -17,9 +17,10 @@
         "url": "/v1/invoices/in_00000000000000/lines",
         "data": [
           {
-            "id": "su_2hksGtIPylSBg2",
+            "id": "sli_9a5f2c19e19776",
             "object": "line_item",
             "type": "subscription",
+            "subscription": "su_2hksGtIPylSBg2",
             "livemode": true,
             "amount": 100,
             "currency": "usd",

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
@@ -6,7 +6,7 @@
   "object": "event",
   "data": {
     "object": {
-      "date": 1380674206,
+      "created": 1380674206,
       "id": "in_00000000000000",
       "period_start": 1378082075,
       "period_end": 1380674075,

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_failed.json
@@ -50,9 +50,10 @@
             "metadata": {}
           },
           {
-            "id": "su_00000000000000",
+            "id": "sli_00000000000000",
             "object": "line_item",
             "type": "subscription",
+            "subscription": "su_2hksGtIPylSBg2",
             "livemode": false,
             "amount": 20000,
             "currency": "usd",

--- a/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.payment_succeeded.json
@@ -23,7 +23,7 @@
       "forgiven": false,
       "lines": {
         "data": [{
-          "id": "sub_00000000000000",
+          "id": "sli_00000000000000",
           "object": "line_item",
           "amount": 50,
           "currency": "eur",
@@ -51,12 +51,12 @@
           },
           "proration": false,
           "quantity": 1,
-          "subscription": null,
+          "subscription": "su_2hksGtIPylSBg2",
           "subscription_item": "si_18ZfWyLrgDIZ7iq8fSlSNGIV",
           "type": "subscription"
         },
         {
-          "id": "sub_00000000000000",
+          "id": "sli_00000000000000",
           "object": "line_item",
           "amount": 50,
           "currency": "eur",
@@ -84,7 +84,7 @@
           },
           "proration": false,
           "quantity": 1,
-          "subscription": null,
+          "subscription": "su_00000000000",
           "subscription_item": "si_18ZfWyLrgDIZ7iq8fSlSNGIV",
           "type": "subscription"
         }],

--- a/lib/stripe_mock/webhook_fixtures/invoice.updated.json
+++ b/lib/stripe_mock/webhook_fixtures/invoice.updated.json
@@ -17,9 +17,10 @@
         "url": "/v1/invoices/in_00000000000000/lines",
         "data": [
           {
-            "id": "su_00000000000000",
+            "id": "sli_00000000000000",
             "object": "line_item",
             "type": "subscription",
+            "subscription": "su_2hksGtIPylSBg2",
             "livemode": true,
             "amount": 100,
             "currency": "usd",

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -255,7 +255,7 @@ shared_examples 'Webhook Events API' do
       expect(invoice_payment_succeeded.data.object.lines.data.class).to be Array
       expect(invoice_payment_succeeded.data.object.lines.data.length).to be 2
       expect(invoice_payment_succeeded.data.object.lines.data.first).to respond_to(:plan)
-      expect(invoice_payment_succeeded.data.object.lines.data.first.id).to eq('sub_00000000000000')
+      expect(invoice_payment_succeeded.data.object.lines.data.first.id).to eq('sli_00000000000000')
     end
   end
 end


### PR DESCRIPTION
1) [https://stripe.com/docs/upgrades#2019-03-14](https://stripe.com/docs/upgrades#2019-03-14)
- The date property has been renamed to created.
2) [https://stripe.com/docs/upgrades#2018-05-21](https://stripe.com/docs/upgrades#2018-05-21)
- Major. The id field of invoice line items of type=subscription no longer can be interpreted as a subscription ID, but instead is a unique invoice line item ID. It can be used for pagination.
