### PR TITLE
Improve PayementIntents responses

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -76,7 +76,6 @@ module StripeMock
         if headers && headers[:idempotency_key]
           if subscriptions.any?
             original_subscription = subscriptions.values.find { |c| c[:idempotency_key] == headers[:idempotency_key]}
-            puts original_subscription
             return subscriptions[original_subscription[:id]] if original_subscription
           end
         end

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -22,7 +22,7 @@ shared_examples 'PaymentIntent API' do
     expect(payment_intent.status).to eq('requires_action')
   end
 
-  it "creates a requires_payment_method stripe payment_intent when amount matches 3184" do
+  it "creates a requires_payment_method stripe payment_intent when amount matches 3178" do
     payment_intent = Stripe::PaymentIntent.create(amount: 3178, currency: "usd")
 
     expect(payment_intent.id).to match(/^test_pi/)
@@ -33,6 +33,16 @@ shared_examples 'PaymentIntent API' do
     expect(payment_intent.last_payment_error.code).to eq('card_declined')
     expect(payment_intent.last_payment_error.decline_code).to eq('insufficient_funds')
     expect(payment_intent.last_payment_error.message).to eq('Not enough funds.')
+  end
+
+  it "creates a requires_capture stripe payment_intent when amount matches 3169" do
+    payment_intent = Stripe::PaymentIntent.create(amount: 3169, currency: "usd")
+
+    expect(payment_intent.id).to match(/^test_pi/)
+    expect(payment_intent.amount).to eq(3169)
+    expect(payment_intent.currency).to eq('usd')
+    expect(payment_intent.metadata.to_hash).to eq({})
+    expect(payment_intent.status).to eq('requires_capture')
   end
 
   describe "listing payment_intent" do


### PR DESCRIPTION
# Changes
This is a follow on #619  to do better support for different use cases.

A `PaymentIntent` can have these following statuses:
- `succeeded`: when it was successfully confirmed and captured
- `requires_action`: when it has to go trough SCA process
- `requires_payment_method`: when it was confirmed successfully (doesn't need SCA) but actual processing of charge failed.
- `requires_capture`: when it was confirmed but it was created with `capture_method: manual` so it needs to be _captured_ separately.

In #619 , there was support for `requires_action` but this PR adds support for two other cases.

When using `FAILED_TRANSACTION_AMOUNT` (which is 3178):
- on creating payment intent, it will be confirmed but will fail and have failure reason in `payment_intent.last_payment_error`
- on _capture_, it will go to `requires_payment_method` and have failure reason in `last_payment_error`.