### PR TITLE
Add invoice settings to customers

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -120,6 +120,7 @@ module StripeMock
     def self.mock_customer(sources, params)
       cus_id = params[:id] || "test_cus_default"
       currency = params[:currency] || StripeMock.default_currency
+      invoice_prefix = SecureRandom.hex(4).upcase
       sources.each {|source| source[:customer] = cus_id}
       {
         email: 'stripe_mock@example.com',
@@ -127,6 +128,12 @@ module StripeMock
         object: "customer",
         created: 1372126710,
         id: cus_id,
+        invoice_prefix: invoice_prefix,
+        invoice_settings: {
+          custom_fields: nil,
+          default_payment_method: nil,
+          footer: nil
+        },
         name: nil,
         livemode: false,
         delinquent: false,

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -228,6 +228,17 @@ shared_examples 'Customer API' do
     expect(customer.discount.start).to be_within(1).of Time.now.to_i
   end
 
+  it 'creates a customer with default invoice settings', live: true do
+    Stripe::Customer.create(id: 'test_cus_invoice_settings')
+    customer = Stripe::Customer.retrieve('test_cus_invoice_settings')
+
+    expect(customer.invoice_prefix).to_not be_nil
+    expect(customer.invoice_settings).to_not be_nil
+    expect(customer.invoice_settings.custom_fields).to be_nil
+    expect(customer.invoice_settings.default_payment_method).to be_nil
+    expect(customer.invoice_settings.footer).to be_nil
+  end
+
   describe 'repeating coupon with duration limit', live: true do
     let!(:coupon) { stripe_helper.create_coupon(id: '10OFF', amount_off: 1000, currency: 'usd', duration: 'repeating', duration_in_months: 12) }
     let!(:customer) { Stripe::Customer.create(coupon: coupon.id) }


### PR DESCRIPTION
Customers were missing `invoice_prefix` and `invoice_settings`.

These changes enables a `PaymentMethod` to be set as the default for invoice or subscription payments, by setting `invoice_settings.default_payment_method` on the `Customer`, to the `PaymentMethod`’s ID, as described here:
https://stripe.com/docs/api/payment_methods/attach