### PR TITLE
Support Tax Rates in subscriptions

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -328,7 +328,8 @@ module StripeMock
               created: 1504035972,
               currency: StripeMock.default_currency
             },
-            quantity: 1
+            quantity: 1,
+            tax_rates: []
           }]
         },
         cancel_at_period_end: false,
@@ -342,6 +343,7 @@ module StripeMock
         quantity: 1,
         tax_percent: nil,
         discount: nil,
+        default_tax_rates: [],
         metadata: {}
       }, params)
     end
@@ -1066,7 +1068,8 @@ module StripeMock
           statement_descriptor: nil,
           trial_period_days: nil
         },
-        quantity: 2
+        quantity: 2,
+        tax_rates: [],
       }.merge(params)
     end
 

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -102,7 +102,13 @@ module StripeMock
           customer[:default_source] = new_card[:id]
         end
 
-        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due idempotency_key)
+        if params[:default_tax_rates]
+          params[:default_tax_rates].each do |tax_rate_id|
+            assert_existence :tax_rates, tax_rate_id, tax_rates[tax_rate_id]
+          end
+        end
+
+        allowed_params = %w(customer application_fee_percent coupon items metadata plan quantity source tax_percent trial_end trial_period_days current_period_start created prorate billing_cycle_anchor billing days_until_due default_tax_rates idempotency_key)
         unknown_params = params.keys - allowed_params.map(&:to_sym)
         if unknown_params.length > 0
           raise Stripe::InvalidRequestError.new("Received unknown parameter: #{unknown_params.join}", unknown_params.first.to_s, http_status: 400)


### PR DESCRIPTION
Following up on #604, this PR adds tax-related fields on subscriptions & items.