### PR TITLE
replace old balance transaction api path with currently supported

### DIFF
--- a/lib/stripe_mock/request_handlers/balance_transactions.rb
+++ b/lib/stripe_mock/request_handlers/balance_transactions.rb
@@ -3,8 +3,8 @@ module StripeMock
     module BalanceTransactions
 
       def BalanceTransactions.included(klass)
-        klass.add_handler 'get /v1/balance/history/(.*)',  :get_balance_transaction
-        klass.add_handler 'get /v1/balance/history',       :list_balance_transactions
+        klass.add_handler 'get /v1/balance_transactions/(.*)',  :get_balance_transaction
+        klass.add_handler 'get /v1/balance_transactions',       :list_balance_transactions
       end
 
       def get_balance_transaction(route, method_url, params, headers)


### PR DESCRIPTION
[https://stripe.com/docs/api/balance_transactions/list](https://stripe.com/docs/api/balance_transactions/list)

> Note that this endpoint was previously called “Balance history” and used the path /v1/balance/history.

