### PR TITLE
Succeded Payment Intents with associated charge

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1131,7 +1131,7 @@ module StripeMock
         client_secret: "pi_1EwXFB2eZvKYlo2CggNnFBo8_secret_vOMkpqZu8ca7hxhfiO80tpT3v",
         confirmation_method: "manual",
         created: 1563208901,
-        currency: "gbp",
+        currency: currency,
         customer: nil,
         description: nil,
         invoice: nil,

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -31,6 +31,9 @@ module StripeMock
             last_payment_error: last_payment_error
           )
         )
+        if params[:confirm]
+          payment_intents[id] = succeeded_payment_intent(payment_intents[id])
+        end
 
         payment_intents[id].clone
       end
@@ -69,18 +72,14 @@ module StripeMock
         route =~ method_url
         payment_intent = assert_existence :payment_intent, $1, payment_intents[$1]
 
-        payment_intent[:status] = 'succeeded'
-        payment_intent[:charges][:data] << Data.mock_charge
-        payment_intent
+        succeeded_payment_intent(payment_intent)
       end
 
       def confirm_payment_intent(route, method_url, params, headers)
         route =~ method_url
         payment_intent = assert_existence :payment_intent, $1, payment_intents[$1]
 
-        payment_intent[:status] = 'succeeded'
-        payment_intent[:charges][:data] << Data.mock_charge
-        payment_intent
+        succeeded_payment_intent(payment_intent)
       end
 
       def cancel_payment_intent(route, method_url, params, headers)
@@ -162,6 +161,13 @@ module StripeMock
           },
           type: "invalid_request_error"
         }
+      end
+
+      def succeeded_payment_intent(payment_intent)
+        payment_intent[:status] = 'succeeded'
+        payment_intent[:charges][:data] << Data.mock_charge
+
+        payment_intent
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -70,6 +70,7 @@ module StripeMock
         payment_intent = assert_existence :payment_intent, $1, payment_intents[$1]
 
         payment_intent[:status] = 'succeeded'
+        payment_intent[:charges][:data] << Data.mock_charge
         payment_intent
       end
 
@@ -78,6 +79,7 @@ module StripeMock
         payment_intent = assert_existence :payment_intent, $1, payment_intents[$1]
 
         payment_intent[:status] = 'succeeded'
+        payment_intent[:charges][:data] << Data.mock_charge
         payment_intent
       end
 

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -73,12 +73,16 @@ shared_examples 'PaymentIntent API' do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")
     confirmed_payment_intent = payment_intent.confirm()
     expect(confirmed_payment_intent.status).to eq("succeeded")
+    expect(confirmed_payment_intent.charges.data.size).to eq(1)
+    expect(confirmed_payment_intent.charges.data.first.object).to eq('charge')
   end
 
   it "captures a stripe payment_intent" do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")
     confirmed_payment_intent = payment_intent.capture()
     expect(confirmed_payment_intent.status).to eq("succeeded")
+    expect(confirmed_payment_intent.charges.data.size).to eq(1)
+    expect(confirmed_payment_intent.charges.data.first.object).to eq('charge')
   end
 
   it "cancels a stripe payment_intent" do

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -69,6 +69,15 @@ shared_examples 'PaymentIntent API' do
     }
   end
 
+  it 'creates and confirms a stripe payment_intent with confirm flag to true' do
+    payment_intent = Stripe::PaymentIntent.create(
+      amount: 100, currency: 'usd', confirm: true
+    )
+    expect(payment_intent.status).to eq('succeeded')
+    expect(payment_intent.charges.data.size).to eq(1)
+    expect(payment_intent.charges.data.first.object).to eq('charge')
+  end
+
   it "confirms a stripe payment_intent" do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")
     confirmed_payment_intent = payment_intent.confirm()


### PR DESCRIPTION
Following the amazing work done by @ashkan18 on #619, supporting [Payment Intents](https://stripe.com/docs/api/payment_intents), now we want to support more complex scenarios. In this PR, we're adding an associated charge once the payment intent is succeeded. Since Stripe supports different ways of confirming/capturing the intent, we tried to support all of them here.

This is our first PR to this repo, so please, feel free to require more info, style changes, and so on.