### PR TITLE
Support stripe-ruby 5.0+ Stripe::CardError.new arguments

### DIFF
--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -59,6 +59,12 @@ module StripeMock
 
       error_values.last.merge!(json_body: { error: json_hash }, http_body: { error: json_hash })
 
+      # In stripe-ruby > 5.0 Stripe::CardError.new third argument was moved
+      # to keyword argument `code`.
+      if Gem::Version.new(Stripe::VERSION) >= Gem::Version.new('5')
+        error_values.last.merge!(code: error_values.delete_at(2))
+      end
+
       error_values
     end
   end


### PR DESCRIPTION
Updating the mock error system to support stripe-ruby 5+ which was released a few days ago.

@see https://github.com/stripe/stripe-ruby/pull/816 for the specific changes

I made it backward-compatible but I don't know what is you policy about it. Otherwise maybe you should bump a major version of `stripe-ruby-mock`.

Otherwise stripe-ruby 5.0 seems to works OK for most of my use cases.