### PR TITLE
The confirm flag on the payment intent should not force the status to "succeeded" when testing a payment intent that requires action

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -200,7 +200,7 @@ module StripeMock
           data: []
         },
         transfer: nil,
-        balance_transaction: "txn_2dyYXXP90MN26R",
+        balance_transaction: params[:balance_transaction_id] || "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
         amount_refunded: 0,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -200,7 +200,7 @@ module StripeMock
           data: []
         },
         transfer: nil,
-        balance_transaction: params[:balance_transaction_id] || "txn_2dyYXXP90MN26R",
+        balance_transaction: "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
         amount_refunded: 0,

--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -200,7 +200,7 @@ module StripeMock
           data: []
         },
         transfer: nil,
-        balance_transaction: "txn_2dyYXXP90MN26R",
+        balance_transaction: params[:balance_transaction] || "txn_2dyYXXP90MN26R",
         failure_message: nil,
         failure_code: nil,
         amount_refunded: 0,

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -169,6 +169,10 @@ module StripeMock
         payment_intent[:status] = 'succeeded'
         btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
         payment_intent[:charges][:data] << Data.mock_charge(balance_transaction: btxn)
+
+        puts "***********************"
+        puts payment_intent[:charges][:data][0][:balance_transaction]
+
         payment_intent
       end
     end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -23,6 +23,12 @@ module StripeMock
         else
           'succeeded'
         end
+
+        puts "*********"
+        puts status
+        puts "*********"
+
+
         last_payment_error = params[:amount] == 3178 ? last_payment_error_generator(code: 'card_declined', decline_code: 'insufficient_funds', message: 'Not enough funds.') : nil
         payment_intents[id] = Data.mock_payment_intent(
           params.merge(

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -169,10 +169,6 @@ module StripeMock
         payment_intent[:status] = 'succeeded'
         btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
         payment_intent[:charges][:data] << Data.mock_charge(balance_transaction: btxn)
-
-        puts "***********************"
-        puts payment_intent[:charges][:data][0][:balance_transaction]
-
         payment_intent
       end
     end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -163,11 +163,10 @@ module StripeMock
 
       def succeeded_payment_intent(payment_intent)
         payment_intent[:status] = 'succeeded'
+        payment_intent[:charges][:data] << Data.mock_charge()
 
         btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
-        payment_intent[:charges][:data] << Data.mock_charge({ balance_transaction_id: btxn })
-
-        #payment_intent[:charges][:data][0][:balance_transaction] = btxn
+        payment_intent[:charges][:data][0][:balance_transaction] = btxn
 
         payment_intent
 

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -24,11 +24,6 @@ module StripeMock
           'succeeded'
         end
 
-        puts "*********"
-        puts status
-        puts "*********"
-
-
         last_payment_error = params[:amount] == 3178 ? last_payment_error_generator(code: 'card_declined', decline_code: 'insufficient_funds', message: 'Not enough funds.') : nil
         payment_intents[id] = Data.mock_payment_intent(
           params.merge(
@@ -37,9 +32,6 @@ module StripeMock
             last_payment_error: last_payment_error
           )
         )
-        if params[:confirm]
-          payment_intents[id] = succeeded_payment_intent(payment_intents[id])
-        end
 
         bal_trans_params = { amount: params[:amount], source: id, application_fee: params[:application_fee] }
         balance_transaction_id = new_balance_transaction('txn', bal_trans_params)

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -168,6 +168,7 @@ module StripeMock
         btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
         payment_intent[:charges][:data][0][:balance_transaction] = btxn
 
+        puts payment_intent[:charges][:data][0][:balance_transaction]
         payment_intent
 
       end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -23,7 +23,6 @@ module StripeMock
         else
           'succeeded'
         end
-
         last_payment_error = params[:amount] == 3178 ? last_payment_error_generator(code: 'card_declined', decline_code: 'insufficient_funds', message: 'Not enough funds.') : nil
         payment_intents[id] = Data.mock_payment_intent(
           params.merge(
@@ -167,7 +166,7 @@ module StripeMock
 
       def succeeded_payment_intent(payment_intent)
         payment_intent[:status] = 'succeeded'
-        btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
+        btxn = new_balance_transaction('txn', { source: payment_intent[:id] })
         payment_intent[:charges][:data] << Data.mock_charge(balance_transaction: btxn)
         payment_intent
       end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -33,13 +33,6 @@ module StripeMock
           )
         )
 
-        bal_trans_params = { amount: params[:amount], source: id, application_fee: params[:application_fee] }
-        balance_transaction_id = new_balance_transaction('txn', bal_trans_params)
-
-        if payment_intents[id][:charges][:data].length > 0
-          payment_intents[id][:charges][:data][0][:balance_transaction] = balance_transaction_id
-        end
-
         payment_intents[id].clone
       end
 
@@ -170,9 +163,14 @@ module StripeMock
 
       def succeeded_payment_intent(payment_intent)
         payment_intent[:status] = 'succeeded'
-        payment_intent[:charges][:data] << Data.mock_charge
+
+        btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
+        payment_intent[:charges][:data] << Data.mock_charge({ balance_transaction_id: btxn })
+
+        #payment_intent[:charges][:data][0][:balance_transaction] = btxn
 
         payment_intent
+
       end
     end
   end

--- a/lib/stripe_mock/request_handlers/payment_intents.rb
+++ b/lib/stripe_mock/request_handlers/payment_intents.rb
@@ -33,6 +33,10 @@ module StripeMock
           )
         )
 
+        if params[:confirm] && status == 'succeeded'
+          payment_intents[id] = succeeded_payment_intent(payment_intents[id])
+        end
+
         payment_intents[id].clone
       end
 
@@ -163,14 +167,9 @@ module StripeMock
 
       def succeeded_payment_intent(payment_intent)
         payment_intent[:status] = 'succeeded'
-        payment_intent[:charges][:data] << Data.mock_charge()
-
         btxn = new_balance_transaction('txn', { amount: payment_intent[:amount], source: payment_intent[:id] })
-        payment_intent[:charges][:data][0][:balance_transaction] = btxn
-
-        puts payment_intent[:charges][:data][0][:balance_transaction]
+        payment_intent[:charges][:data] << Data.mock_charge(balance_transaction: btxn)
         payment_intent
-
       end
     end
   end

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -70,14 +70,6 @@ shared_examples 'PaymentIntent API' do
     }
   end
 
-  it 'creates and confirms a stripe payment_intent with confirm flag to true' do
-    payment_intent = Stripe::PaymentIntent.create(
-      amount: 100, currency: 'usd', confirm: true
-    )
-    expect(payment_intent.status).to eq('succeeded')
-    expect(payment_intent.charges.data.size).to eq(1)
-    expect(payment_intent.charges.data.first.object).to eq('charge')
-  end
 
   it "confirms a stripe payment_intent" do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -80,7 +80,6 @@ shared_examples 'PaymentIntent API' do
     balance_txn = payment_intent.charges.data.first.balance_transaction
     expect(balance_txn).to match(/^test_txn/)
     expect(Stripe::BalanceTransaction.retrieve(balance_txn).id).to eq(balance_txn)
-    expect(Stripe::BalanceTransaction.retrieve(balance_txn).amount).to eq(payment_intent.amount)
   end
 
   it "confirms a stripe payment_intent" do

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -80,6 +80,7 @@ shared_examples 'PaymentIntent API' do
     balance_txn = payment_intent.charges.data.first.balance_transaction
     expect(balance_txn).to match(/^test_txn/)
     expect(Stripe::BalanceTransaction.retrieve(balance_txn).id).to eq(balance_txn)
+    expect(Stripe::BalanceTransaction.retrieve(balance_txn).amount).to eq(payment_intent.amount)
   end
 
   it "confirms a stripe payment_intent" do

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -70,6 +70,17 @@ shared_examples 'PaymentIntent API' do
     }
   end
 
+  it 'creates and confirms a stripe payment_intent with confirm flag to true' do
+    payment_intent = Stripe::PaymentIntent.create(
+      amount: 100, currency: 'usd', confirm: true
+    )
+    expect(payment_intent.status).to eq('succeeded')
+    expect(payment_intent.charges.data.size).to eq(1)
+    expect(payment_intent.charges.data.first.object).to eq('charge')
+    balance_txn = payment_intent.charges.data.first.balance_transaction
+    expect(balance_txn).to match(/^test_txn/)
+    expect(Stripe::BalanceTransaction.retrieve(balance_txn).id).to eq(balance_txn)
+  end
 
   it "confirms a stripe payment_intent" do
     payment_intent = Stripe::PaymentIntent.create(amount: 100, currency: "usd")


### PR DESCRIPTION
* when testing a payment intent status that requires action (as in 3d auth scenario), the confirm flag should not force the payment intent status to succeeded.
* the payment intent balance transaction should be retrievable when a payment intent succeeds.


