### PR TITLE
add invoice_settings on mock_customer

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -134,6 +134,11 @@ module StripeMock
         discount: nil,
         account_balance: 0,
         currency: currency,
+        invoice_settings: {
+          default_payment_method: nil,
+          custom_fields: nil,
+          footer: nil
+        },
         sources: {
           object: "list",
           total_count: sources.size,
@@ -1184,7 +1189,7 @@ module StripeMock
 
       }.merge(params)
     end
-    
+
     def self.mock_setup_intent(params = {})
       setup_intent_id = params[:id] || "seti_1F96eK2aLAadsDqo0AVIyPmC"
       {

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -273,6 +273,7 @@ module StripeMock
       # 3) has billing set to send invoice
       def verify_card_present(customer, plan, subscription, params={})
         return if customer[:default_source]
+        return if customer[:invoice_settings][:default_payment_method]
         return if customer[:trial_end]
         return if params[:trial_end]
 

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -27,6 +27,17 @@ shared_examples 'Customer API' do
     expect { customer.source }.to raise_error
   end
 
+  it "creates a stripe customer with a default payment method" do
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      invoice_settings: {
+        default_payment_method: "pm_1ExEuFL2DI6wht39WNJgbybl"
+      },
+      description: "a description"
+    })
+    expect(customer.invoice_settings.default_payment_method).to eq("pm_1ExEuFL2DI6wht39WNJgbybl")
+  end
+
   it "creates a stripe customer with multiple cards and updates the default card" do
     card_a   = gen_card_tk
     card_b   = gen_card_tk


### PR DESCRIPTION
Right now I'm getting `undefined method invoice_settings for #<Stripe::Customer:0x00007fb1e13ff198>` and looks like this part is missing on customer data.