### PR TITLE
Make the gem compatible with Stripe Gem v.5

### DIFF
--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -15,27 +15,27 @@ module StripeMock
   def self.prepare_card_error(code, *handler_names)
     handler_names.push(:new_charge) if handler_names.count == 0
 
-    args = CardErrors.argument_map[code]
-    raise StripeMockError.new("Unrecognized stripe card error code: #{code}") if args.nil?
-    self.prepare_error Stripe::CardError.new(*args), *handler_names
+    error = CardErrors.argument_map[code]
+    raise StripeMockError.new("Unrecognized stripe card error code: #{code}") if error.nil?
+    self.prepare_error error, *handler_names
   end
 
   module CardErrors
 
     def self.argument_map
       @__map ||= {
-        incorrect_number: add_json_body(["The card number is incorrect", 'number', 'incorrect_number', http_status: 402]),
-        invalid_number: add_json_body(["The card number is not a valid credit card number", 'number', 'invalid_number', http_status: 402]),
-        invalid_expiry_month: add_json_body(["The card's expiration month is invalid", 'exp_month', 'invalid_expiry_month', http_status: 402]),
-        invalid_expiry_year: add_json_body(["The card's expiration year is invalid", 'exp_year', 'invalid_expiry_year', http_status: 402]),
-        invalid_cvc: add_json_body(["The card's security code is invalid", 'cvc', 'invalid_cvc', http_status: 402]),
-        expired_card: add_json_body(["The card has expired", 'exp_month', 'expired_card', http_status: 402]),
-        incorrect_cvc: add_json_body(["The card's security code is incorrect", 'cvc', 'incorrect_cvc', http_status: 402]),
-        card_declined: add_json_body(["The card was declined", nil, 'card_declined', http_status: 402]),
-        missing: add_json_body(["There is no card on a customer that is being charged.", nil, 'missing', http_status: 402]),
-        processing_error: add_json_body(["An error occurred while processing the card", nil, 'processing_error', http_status: 402]),
-        card_error: add_json_body(['The card number is not a valid credit card number.', 'number', 'invalid_number', http_status: 402]),
-        incorrect_zip: add_json_body(['The zip code you supplied failed validation.', 'address_zip', 'incorrect_zip', http_status: 402])
+        incorrect_number: add_json_body("The card number is incorrect", 'number', code: 'incorrect_number', http_status: 402),
+        invalid_number: add_json_body("The card number is not a valid credit card number", 'number', code:  'invalid_number', http_status: 402),
+        invalid_expiry_month: add_json_body("The card's expiration month is invalid", 'exp_month', code:  'invalid_expiry_month', http_status: 402),
+        invalid_expiry_year: add_json_body("The card's expiration year is invalid", 'exp_year', code:  'invalid_expiry_year', http_status: 402),
+        invalid_cvc: add_json_body("The card's security code is invalid", 'cvc', code:  'invalid_cvc', http_status: 402),
+        expired_card: add_json_body("The card has expired", 'exp_month', code:  'expired_card', http_status: 402),
+        incorrect_cvc: add_json_body("The card's security code is incorrect", 'cvc', code:  'incorrect_cvc', http_status: 402),
+        card_declined: add_json_body("The card was declined", nil, code:  'card_declined', http_status: 402),
+        missing: add_json_body("There is no card on a customer that is being charged.", nil, code:  'missing', http_status: 402),
+        processing_error: add_json_body("An error occurred while processing the card", nil, code:  'processing_error', http_status: 402),
+        card_error: add_json_body('The card number is not a valid credit card number.', 'number', code:  'invalid_number', http_status: 402),
+        incorrect_zip: add_json_body('The zip code you supplied failed validation.', 'address_zip', code:  'incorrect_zip', http_status: 402)
       }
     end
 
@@ -50,16 +50,18 @@ module StripeMock
       decline_code_map[code_key]
     end
 
-    def self.add_json_body(error_values)
-      error_keys = [:message, :param, :code]
+    def self.add_json_body(message, param, **kwargs)
+      json_hash = {
+        message: message,
+        param: param,
+        code: kwargs[:code],
+        type: 'card_error',
+        decline_code: get_decline_code(kwargs[:code])
+      }
 
-      json_hash = Hash[error_keys.zip error_values]
-      json_hash[:type] = 'card_error'
-      json_hash[:decline_code] = get_decline_code(json_hash[:code])
+      error_keyword_args = kwargs.merge({ json_body: { error: json_hash }, http_body: { error: json_hash }.to_json })
 
-      error_values.last.merge!(json_body: { error: json_hash }, http_body: { error: json_hash })
-
-      error_values
+      Stripe::CardError.new(message, param, **error_keyword_args)
     end
   end
 end

--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -15,28 +15,27 @@ module StripeMock
   def self.prepare_card_error(code, *handler_names)
     handler_names.push(:new_charge) if handler_names.count == 0
 
-    error = CardErrors.argument_map[code]
+    error = CardErrors.build_error_for(code)
     raise StripeMockError.new("Unrecognized stripe card error code: #{code}") if error.nil?
     self.prepare_error error, *handler_names
   end
 
   module CardErrors
-
-    def self.argument_map
-      @__map ||= {
-        incorrect_number: add_json_body("The card number is incorrect", 'number', code: 'incorrect_number', http_status: 402),
-        invalid_number: add_json_body("The card number is not a valid credit card number", 'number', code:  'invalid_number', http_status: 402),
-        invalid_expiry_month: add_json_body("The card's expiration month is invalid", 'exp_month', code:  'invalid_expiry_month', http_status: 402),
-        invalid_expiry_year: add_json_body("The card's expiration year is invalid", 'exp_year', code:  'invalid_expiry_year', http_status: 402),
-        invalid_cvc: add_json_body("The card's security code is invalid", 'cvc', code:  'invalid_cvc', http_status: 402),
-        expired_card: add_json_body("The card has expired", 'exp_month', code:  'expired_card', http_status: 402),
-        incorrect_cvc: add_json_body("The card's security code is incorrect", 'cvc', code:  'incorrect_cvc', http_status: 402),
-        card_declined: add_json_body("The card was declined", nil, code:  'card_declined', http_status: 402),
-        missing: add_json_body("There is no card on a customer that is being charged.", nil, code:  'missing', http_status: 402),
-        processing_error: add_json_body("An error occurred while processing the card", nil, code:  'processing_error', http_status: 402),
-        card_error: add_json_body('The card number is not a valid credit card number.', 'number', code:  'invalid_number', http_status: 402),
-        incorrect_zip: add_json_body('The zip code you supplied failed validation.', 'address_zip', code:  'incorrect_zip', http_status: 402)
-      }
+    def self.build_error_for(code)
+      case code
+      when :incorrect_number then build_card_error("The card number is incorrect", 'number', code: 'incorrect_number', http_status: 402)
+      when :invalid_number then build_card_error("The card number is not a valid credit card number", 'number', code:  'invalid_number', http_status: 402)
+      when :invalid_expiry_month then build_card_error("The card's expiration month is invalid", 'exp_month', code:  'invalid_expiry_month', http_status: 402)
+      when :invalid_expiry_year then build_card_error("The card's expiration year is invalid", 'exp_year', code:  'invalid_expiry_year', http_status: 402)
+      when :invalid_cvc then build_card_error("The card's security code is invalid", 'cvc', code:  'invalid_cvc', http_status: 402)
+      when :expired_card then build_card_error("The card has expired", 'exp_month', code:  'expired_card', http_status: 402)
+      when :incorrect_cvc then build_card_error("The card's security code is incorrect", 'cvc', code:  'incorrect_cvc', http_status: 402)
+      when :card_declined then build_card_error("The card was declined", nil, code:  'card_declined', http_status: 402)
+      when :missing then build_card_error("There is no card on a customer that is being charged.", nil, code:  'missing', http_status: 402)
+      when :processing_error then build_card_error("An error occurred while processing the card", nil, code:  'processing_error', http_status: 402)
+      when :card_error then build_card_error('The card number is not a valid credit card number.', 'number', code:  'invalid_number', http_status: 402)
+      when :incorrect_zip then build_card_error('The zip code you supplied failed validation.', 'address_zip', code:  'incorrect_zip', http_status: 402)
+      end
     end
 
     def self.get_decline_code(code)
@@ -50,7 +49,7 @@ module StripeMock
       decline_code_map[code_key]
     end
 
-    def self.add_json_body(message, param, **kwargs)
+    def self.build_card_error(message, param, **kwargs)
       json_hash = {
         message: message,
         param: param,
@@ -59,7 +58,7 @@ module StripeMock
         decline_code: get_decline_code(kwargs[:code])
       }
 
-      error_keyword_args = kwargs.merge({ json_body: { error: json_hash }, http_body: { error: json_hash }.to_json })
+      error_keyword_args = kwargs.merge(json_body: { error: json_hash }, http_body: { error: json_hash }.to_json)
 
       Stripe::CardError.new(message, param, **error_keyword_args)
     end

--- a/lib/stripe_mock/api/errors.rb
+++ b/lib/stripe_mock/api/errors.rb
@@ -1,5 +1,4 @@
 module StripeMock
-
   def self.prepare_error(stripe_error, *handler_names)
     handler_names.push(:all) if handler_names.count == 0
 
@@ -16,25 +15,28 @@ module StripeMock
     handler_names.push(:new_charge) if handler_names.count == 0
 
     error = CardErrors.build_error_for(code)
-    raise StripeMockError.new("Unrecognized stripe card error code: #{code}") if error.nil?
-    self.prepare_error error, *handler_names
+    if error.nil?
+      raise StripeMockError, "Unrecognized stripe card error code: #{code}"
+    end
+
+    prepare_error error, *handler_names
   end
 
   module CardErrors
     def self.build_error_for(code)
       case code
-      when :incorrect_number then build_card_error("The card number is incorrect", 'number', code: 'incorrect_number', http_status: 402)
-      when :invalid_number then build_card_error("The card number is not a valid credit card number", 'number', code:  'invalid_number', http_status: 402)
-      when :invalid_expiry_month then build_card_error("The card's expiration month is invalid", 'exp_month', code:  'invalid_expiry_month', http_status: 402)
-      when :invalid_expiry_year then build_card_error("The card's expiration year is invalid", 'exp_year', code:  'invalid_expiry_year', http_status: 402)
-      when :invalid_cvc then build_card_error("The card's security code is invalid", 'cvc', code:  'invalid_cvc', http_status: 402)
-      when :expired_card then build_card_error("The card has expired", 'exp_month', code:  'expired_card', http_status: 402)
-      when :incorrect_cvc then build_card_error("The card's security code is incorrect", 'cvc', code:  'incorrect_cvc', http_status: 402)
-      when :card_declined then build_card_error("The card was declined", nil, code:  'card_declined', http_status: 402)
-      when :missing then build_card_error("There is no card on a customer that is being charged.", nil, code:  'missing', http_status: 402)
-      when :processing_error then build_card_error("An error occurred while processing the card", nil, code:  'processing_error', http_status: 402)
-      when :card_error then build_card_error('The card number is not a valid credit card number.', 'number', code:  'invalid_number', http_status: 402)
-      when :incorrect_zip then build_card_error('The zip code you supplied failed validation.', 'address_zip', code:  'incorrect_zip', http_status: 402)
+      when :incorrect_number then build_card_error('The card number is incorrect', 'number', code: 'incorrect_number', http_status: 402)
+      when :invalid_number then build_card_error('The card number is not a valid credit card number', 'number', code:  'invalid_number', http_status: 402)
+      when :invalid_expiry_month then build_card_error("The card's expiration month is invalid", 'exp_month', code: 'invalid_expiry_month', http_status: 402)
+      when :invalid_expiry_year then build_card_error("The card's expiration year is invalid", 'exp_year', code: 'invalid_expiry_year', http_status: 402)
+      when :invalid_cvc then build_card_error("The card's security code is invalid", 'cvc', code: 'invalid_cvc', http_status: 402)
+      when :expired_card then build_card_error('The card has expired', 'exp_month', code: 'expired_card', http_status: 402)
+      when :incorrect_cvc then build_card_error("The card's security code is incorrect", 'cvc', code: 'incorrect_cvc', http_status: 402)
+      when :card_declined then build_card_error('The card was declined', nil, code: 'card_declined', http_status: 402)
+      when :missing then build_card_error('There is no card on a customer that is being charged.', nil, code: 'missing', http_status: 402)
+      when :processing_error then build_card_error('An error occurred while processing the card', nil, code: 'processing_error', http_status: 402)
+      when :card_error then build_card_error('The card number is not a valid credit card number.', 'number', code: 'invalid_number', http_status: 402)
+      when :incorrect_zip then build_card_error('The zip code you supplied failed validation.', 'address_zip', code: 'incorrect_zip', http_status: 402)
       end
     end
 

--- a/lib/stripe_mock/test_strategies/base.rb
+++ b/lib/stripe_mock/test_strategies/base.rb
@@ -102,7 +102,7 @@ module StripeMock
       end
 
       def delete_all_coupons
-        coupons = Stripe::Coupon.all
+        coupons = Stripe::Coupon.list
         coupons.data.map(&:delete) if coupons.data.count > 0
       end
 

--- a/lib/stripe_mock/test_strategies/live.rb
+++ b/lib/stripe_mock/test_strategies/live.rb
@@ -11,7 +11,7 @@ module StripeMock
 
       def delete_product(product_id)
         product = Stripe::Product.retrieve(product_id)
-        Stripe::Plan.all(product: product_id).each(&:delete) if product.type == 'service'
+        Stripe::Plan.list(product: product_id).each(&:delete) if product.type == 'service'
         product.delete
       rescue Stripe::StripeError => e
         # do nothing

--- a/spec/shared_stripe_examples/account_examples.rb
+++ b/spec/shared_stripe_examples/account_examples.rb
@@ -15,7 +15,7 @@ shared_examples 'Account API' do
       expect(account.id).to match /acct\_/
     end
     it 'retrieves all' do
-      accounts = Stripe::Account.all
+      accounts = Stripe::Account.list
 
       expect(accounts).to be_a Stripe::ListObject
       expect(accounts.data.count).to satisfy { |n| n >= 1 }

--- a/spec/shared_stripe_examples/balance_transaction_examples.rb
+++ b/spec/shared_stripe_examples/balance_transaction_examples.rb
@@ -26,7 +26,7 @@ shared_examples 'Balance Transaction API' do
   describe "listing balance transactions" do
 
     it "retrieves all balance transactions" do
-      disputes = Stripe::BalanceTransaction.all
+      disputes = Stripe::BalanceTransaction.list
 
       expect(disputes.count).to eq(10)
       expect(disputes.map &:id).to include('txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI')
@@ -38,7 +38,7 @@ shared_examples 'Balance Transaction API' do
     transfer_id = Stripe::Transfer.create({ amount: 2730, currency: "usd" })
 
     # verify transfer currently has no balance transactions
-    transfer_transactions = Stripe::BalanceTransaction.all({transfer: transfer_id})
+    transfer_transactions = Stripe::BalanceTransaction.list({transfer: transfer_id})
     expect(transfer_transactions.count).to eq(0)
 
     # verify we can create a new balance transaction associated with the transfer
@@ -55,7 +55,7 @@ shared_examples 'Balance Transaction API' do
     stripe_helper.upsert_stripe_object(:balance_transaction, {id: existing_txn_id, transfer: transfer_id})
 
     # now verify that only these balance transactions are retrieved with the transfer
-    transfer_transactions = Stripe::BalanceTransaction.all({transfer: transfer_id})
+    transfer_transactions = Stripe::BalanceTransaction.list({transfer: transfer_id})
     expect(transfer_transactions.count).to eq(2)
     expect(transfer_transactions.map &:id).to include(new_txn_id, existing_txn_id)
   end

--- a/spec/shared_stripe_examples/bank_examples.rb
+++ b/spec/shared_stripe_examples/bank_examples.rb
@@ -77,7 +77,7 @@ shared_examples 'Bank API' do
     let!(:bank) { customer.sources.create(source: bank_token) }
 
     it "can retrieve all customer's banks" do
-      retrieved = customer.sources.all
+      retrieved = customer.sources.list
       expect(retrieved.count).to eq(1)
     end
 
@@ -174,7 +174,7 @@ shared_examples 'Bank API' do
 
       customer = Stripe::Customer.retrieve('test_customer_bank')
 
-      list = customer.sources.all
+      list = customer.sources.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(2)
@@ -191,7 +191,7 @@ shared_examples 'Bank API' do
       Stripe::Customer.create(id: 'no_banks')
       customer = Stripe::Customer.retrieve('no_banks')
 
-      list = customer.sources.all
+      list = customer.sources.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(0)

--- a/spec/shared_stripe_examples/card_examples.rb
+++ b/spec/shared_stripe_examples/card_examples.rb
@@ -134,7 +134,7 @@ shared_examples 'Card API' do
     let!(:card) { customer.sources.create(source: card_token) }
 
     it "can retrieve all customer's cards" do
-      retrieved = customer.sources.all
+      retrieved = customer.sources.list
       expect(retrieved.count).to eq(1)
     end
 
@@ -198,7 +198,7 @@ shared_examples 'Card API' do
     let!(:card) { recipient.cards.create(card: card_token) }
 
     it "can retrieve all recipient's cards" do
-      retrieved = recipient.cards.all
+      retrieved = recipient.cards.list
       expect(retrieved.count).to eq(1)
     end
 
@@ -279,7 +279,7 @@ shared_examples 'Card API' do
 
       customer = Stripe::Customer.retrieve('test_customer_card')
 
-      list = customer.sources.all
+      list = customer.sources.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(2)
@@ -296,7 +296,7 @@ shared_examples 'Card API' do
       Stripe::Customer.create(id: 'no_cards')
       customer = Stripe::Customer.retrieve('no_cards')
 
-      list = customer.sources.all
+      list = customer.sources.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(0)

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -278,20 +278,6 @@ shared_examples 'Charge API' do
     }.not_to raise_error
   end
 
-  it "marks a charge as safe" do
-    original = Stripe::Charge.create({
-      amount: 777,
-      currency: 'USD',
-      source: stripe_helper.generate_card_token
-    })
-    charge = Stripe::Charge.retrieve(original.id)
-
-    charge.mark_as_safe
-
-    updated = Stripe::Charge.retrieve(original.id)
-    expect(updated.fraud_details[:user_report]).to eq "safe"
-  end
-
   it "does not lose data when updating a charge" do
     original = Stripe::Charge.create({
       amount: 777,

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -361,24 +361,24 @@ shared_examples 'Charge API' do
     end
 
     it "stores all charges in memory" do
-      expect(Stripe::Charge.all.data.map(&:id).reverse).to eq([@charge.id, @charge2.id])
+      expect(Stripe::Charge.list.data.map(&:id).reverse).to eq([@charge.id, @charge2.id])
     end
 
     it "defaults count to 10 charges" do
       11.times { Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
 
-      expect(Stripe::Charge.all.data.count).to eq(10)
+      expect(Stripe::Charge.list.data.count).to eq(10)
     end
 
     it "is marked as having more when more objects exist" do
       11.times { Stripe::Charge.create(amount: 1, currency: 'usd', source: stripe_helper.generate_card_token) }
 
-      expect(Stripe::Charge.all.has_more).to eq(true)
+      expect(Stripe::Charge.list.has_more).to eq(true)
     end
 
     context "when passing limit" do
       it "gets that many charges" do
-        expect(Stripe::Charge.all(limit: 1).count).to eq(1)
+        expect(Stripe::Charge.list(limit: 1).count).to eq(1)
       end
     end
   end
@@ -398,13 +398,13 @@ shared_examples 'Charge API' do
       Stripe::Charge.create(customer: cus.id, amount: 100, currency: "usd")
     end
 
-    all = Stripe::Charge.all
+    all_charges = Stripe::Charge.list
     default_limit = 10
-    half = Stripe::Charge.all(starting_after: all.data.at(1).id)
+    half = Stripe::Charge.list(starting_after: all_charges.data.at(1).id)
 
     expect(half).to be_a(Stripe::ListObject)
     expect(half.data.count).to eq(default_limit)
-    expect(half.data.first.id).to eq(all.data.at(2).id)
+    expect(half.data.first.id).to eq(all_charges.data.at(2).id)
   end
 
 

--- a/spec/shared_stripe_examples/charge_examples.rb
+++ b/spec/shared_stripe_examples/charge_examples.rb
@@ -343,7 +343,8 @@ shared_examples 'Charge API' do
     end
 
     it "stores charges for a customer in memory" do
-      expect(@customer.charges.data.map(&:id)).to eq([@charge.id])
+      charges = Stripe::Charge.list(customer: @customer.id)
+      expect(charges.map(&:id)).to eq([@charge.id])
     end
 
     it "stores all charges in memory" do

--- a/spec/shared_stripe_examples/coupon_examples.rb
+++ b/spec/shared_stripe_examples/coupon_examples.rb
@@ -53,7 +53,7 @@ shared_examples 'Coupon API' do
       coupon1
       coupon2
 
-      all = Stripe::Coupon.all
+      all = Stripe::Coupon.list
 
       expect(all.count).to eq(2)
       expect(all.map &:id).to include('10BUCKS', '11BUCKS')

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -327,7 +327,7 @@ shared_examples 'Customer API' do
     Stripe::Customer.create({ email: 'one@one.com' })
     Stripe::Customer.create({ email: 'two@two.com' })
 
-    all = Stripe::Customer.all
+    all = Stripe::Customer.list
     expect(all.count).to eq(2)
     expect(all.map &:email).to include('one@one.com', 'two@two.com')
   end

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -439,14 +439,6 @@ shared_examples 'Customer API' do
     expect(customer.deleted).to eq(true)
   end
 
-  it 'works with the update_subscription method' do
-    stripe_helper.create_plan(id: 'silver', product: product.id)
-    cus   = Stripe::Customer.create(source: gen_card_tk)
-    expect {
-      cus.update_subscription(plan: 'silver')
-    }.not_to raise_error
-  end
-
   it "deletes a stripe customer discount" do
     original = Stripe::Customer.create(id: 'test_customer_update')
 

--- a/spec/shared_stripe_examples/dispute_examples.rb
+++ b/spec/shared_stripe_examples/dispute_examples.rb
@@ -71,14 +71,14 @@ shared_examples 'Dispute API' do
   describe "listing disputes" do
 
     it "retrieves all disputes" do
-      disputes = Stripe::Dispute.all
+      disputes = Stripe::Dispute.list
 
       expect(disputes.count).to eq(10)
       expect(disputes.map &:id).to include('dp_05RsQX2eZvKYlo2C0FRTGSSA','dp_15RsQX2eZvKYlo2C0ERTYUIA', 'dp_25RsQX2eZvKYlo2C0ZXCVBNM', 'dp_35RsQX2eZvKYlo2C0QAZXSWE', 'dp_45RsQX2eZvKYlo2C0EDCVFRT', 'dp_55RsQX2eZvKYlo2C0OIKLJUY', 'dp_65RsQX2eZvKYlo2C0ASDFGHJ', 'dp_75RsQX2eZvKYlo2C0EDCXSWQ', 'dp_85RsQX2eZvKYlo2C0UJMCDET', 'dp_95RsQX2eZvKYlo2C0EDFRYUI')
     end
 
     it "retrieves disputes with a limit(3)" do
-      disputes = Stripe::Dispute.all(limit: 3)
+      disputes = Stripe::Dispute.list(limit: 3)
 
       expect(disputes.count).to eq(3)
       expected = ['dp_95RsQX2eZvKYlo2C0EDFRYUI','dp_85RsQX2eZvKYlo2C0UJMCDET', 'dp_75RsQX2eZvKYlo2C0EDCXSWQ']

--- a/spec/shared_stripe_examples/error_mock_examples.rb
+++ b/spec/shared_stripe_examples/error_mock_examples.rb
@@ -6,13 +6,14 @@ def expect_card_error(code, param)
     expect(e.http_status).to eq(402)
     expect(e.code).to eq(code)
     expect(e.param).to eq(param)
+    expect(e.http_body).to eq(e.json_body.to_json)
   }
 end
 
 shared_examples 'Stripe Error Mocking' do
 
   it "mocks a manually given stripe card error" do
-    error = Stripe::CardError.new('Test Msg', 'param_name', 'bad_code', http_status: 444, http_body: 'body', json_body: 'json body')
+    error = Stripe::CardError.new('Test Msg', 'param_name', code: 'bad_code', http_status: 444, http_body: 'body', json_body: {})
     StripeMock.prepare_error(error)
 
     expect { Stripe::Customer.create() }.to raise_error {|e|
@@ -23,14 +24,14 @@ shared_examples 'Stripe Error Mocking' do
 
       expect(e.http_status).to eq(444)
       expect(e.http_body).to eq('body')
-      expect(e.json_body).to eq('json body')
+      expect(e.json_body).to eq({})
     }
   end
 
 
   it "mocks a manually gives stripe invalid request error" do
 
-    error = Stripe::InvalidRequestError.new('Test Invalid', 'param', http_status: 987, http_body: 'ibody', json_body: 'json ibody')
+    error = Stripe::InvalidRequestError.new('Test Invalid', 'param', http_status: 987, http_body: 'ibody', json_body: {})
     StripeMock.prepare_error(error)
 
     expect { Stripe::Charge.create(amount: 1, currency: 'usd') }.to raise_error {|e|
@@ -40,13 +41,13 @@ shared_examples 'Stripe Error Mocking' do
 
       expect(e.http_status).to eq(987)
       expect(e.http_body).to eq('ibody')
-      expect(e.json_body).to eq('json ibody')
+      expect(e.json_body).to eq({})
     }
   end
 
 
   it "mocks a manually gives stripe invalid auth error" do
-    error = Stripe::AuthenticationError.new('Bad Auth', http_status: 499, http_body: 'abody', json_body: 'json abody')
+    error = Stripe::AuthenticationError.new('Bad Auth', http_status: 499, http_body: 'abody', json_body: {})
     StripeMock.prepare_error(error)
 
     expect { stripe_helper.create_plan(id: "test_plan") }.to raise_error {|e|
@@ -55,7 +56,7 @@ shared_examples 'Stripe Error Mocking' do
 
       expect(e.http_status).to eq(499)
       expect(e.http_body).to eq('abody')
-      expect(e.json_body).to eq('json abody')
+      expect(e.json_body).to eq({})
     }
   end
 

--- a/spec/shared_stripe_examples/external_account_examples.rb
+++ b/spec/shared_stripe_examples/external_account_examples.rb
@@ -63,7 +63,7 @@ shared_examples 'External Account API' do
     let!(:bank) { account.external_accounts.create(external_account: bank_token) }
 
     it "can retrieve all account's banks" do
-      retrieved = account.external_accounts.all
+      retrieved = account.external_accounts.list
       expect(retrieved.count).to eq(1)
     end
 
@@ -142,7 +142,7 @@ shared_examples 'External Account API' do
 
       account = Stripe::Account.retrieve('test_account')
 
-      list = account.external_accounts.all
+      list = account.external_accounts.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(2)
@@ -159,7 +159,7 @@ shared_examples 'External Account API' do
       Stripe::Account.create(id: 'no_banks', type: 'custom', country: "US")
       account = Stripe::Account.retrieve('no_banks')
 
-      list = account.external_accounts.all
+      list = account.external_accounts.list
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(0)

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -48,7 +48,8 @@ shared_examples 'Invoice API' do
     end
 
     it "stores invoices for a customer in memory" do
-      expect(@customer.invoices.map(&:id)).to eq([@invoice.id])
+      invoices = Stripe::Invoice.list(customer: @customer.id)
+      expect(invoices.map(&:id)).to eq([@invoice.id])
     end
 
     it "stores all invoices in memory" do

--- a/spec/shared_stripe_examples/invoice_examples.rb
+++ b/spec/shared_stripe_examples/invoice_examples.rb
@@ -52,23 +52,23 @@ shared_examples 'Invoice API' do
     end
 
     it "stores all invoices in memory" do
-      expect(Stripe::Invoice.all.map(&:id)).to match_array([@invoice.id, @invoice2.id])
+      expect(Stripe::Invoice.list.map(&:id)).to match_array([@invoice.id, @invoice2.id])
     end
 
     it "defaults count to 10 invoices" do
       11.times { Stripe::Invoice.create }
-      expect(Stripe::Invoice.all.count).to eq(10)
+      expect(Stripe::Invoice.list.count).to eq(10)
     end
 
     it "is marked as having more when more objects exist" do
       11.times { Stripe::Invoice.create }
 
-      expect(Stripe::Invoice.all.has_more).to eq(true)
+      expect(Stripe::Invoice.list.has_more).to eq(true)
     end
 
     context "when passing limit" do
       it "gets that many invoices" do
-        expect(Stripe::Invoice.all(limit: 1).count).to eq(1)
+        expect(Stripe::Invoice.list(limit: 1).count).to eq(1)
       end
     end
   end
@@ -429,7 +429,7 @@ shared_examples 'Invoice API' do
     context 'retrieving invoice line items' do
       it 'returns all line items for created invoice' do
         invoice = Stripe::Invoice.create(customer: customer.id)
-        line_items = invoice.lines.all
+        line_items = invoice.lines.list
 
         expect(invoice).to be_a Stripe::Invoice
         expect(line_items.count).to eq(1)

--- a/spec/shared_stripe_examples/invoice_item_examples.rb
+++ b/spec/shared_stripe_examples/invoice_item_examples.rb
@@ -39,7 +39,7 @@ shared_examples 'Invoice Item API' do
     end
 
     it "retrieves all invoice items" do
-      all = Stripe::InvoiceItem.all
+      all = Stripe::InvoiceItem.list
       expect(all.count).to eq(2)
       expect(all.map &:amount).to include(1075, 1540)
     end

--- a/spec/shared_stripe_examples/payment_intent_examples.rb
+++ b/spec/shared_stripe_examples/payment_intent_examples.rb
@@ -44,11 +44,11 @@ shared_examples 'PaymentIntent API' do
     end
 
     it "without params retrieves all stripe payment_intent" do
-      expect(Stripe::PaymentIntent.all.count).to eq(3)
+      expect(Stripe::PaymentIntent.list.count).to eq(3)
     end
 
     it "accepts a limit param" do
-      expect(Stripe::PaymentIntent.all(limit: 2).count).to eq(2)
+      expect(Stripe::PaymentIntent.list(limit: 2).count).to eq(2)
     end
   end
 

--- a/spec/shared_stripe_examples/payout_examples.rb
+++ b/spec/shared_stripe_examples/payout_examples.rb
@@ -19,11 +19,11 @@ shared_examples 'Payout API' do
     end
 
     it "without params retrieves all tripe payouts" do
-      expect(Stripe::Payout.all.count).to eq(3)
+      expect(Stripe::Payout.list.count).to eq(3)
     end
 
     it "accepts a limit param" do
-      expect(Stripe::Payout.all(limit: 2).count).to eq(2)
+      expect(Stripe::Payout.list(limit: 2).count).to eq(2)
     end
   end
 

--- a/spec/shared_stripe_examples/plan_examples.rb
+++ b/spec/shared_stripe_examples/plan_examples.rb
@@ -105,7 +105,7 @@ shared_examples 'Plan API' do
     stripe_helper.create_plan(id: 'Plan One', product: product_id, amount: 54321)
     stripe_helper.create_plan(id: 'Plan Two', product: product_id, amount: 98765)
 
-    all = Stripe::Plan.all
+    all = Stripe::Plan.list
     expect(all.count).to eq(2)
     expect(all.map &:id).to include('Plan One', 'Plan Two')
     expect(all.map &:amount).to include(54321, 98765)
@@ -115,7 +115,7 @@ shared_examples 'Plan API' do
     101.times do | i|
       stripe_helper.create_plan(id: "Plan #{i}", product: product_id, amount: 11)
     end
-    all = Stripe::Plan.all(limit: 100)
+    all = Stripe::Plan.list(limit: 100)
 
     expect(all.count).to eq(100)
   end

--- a/spec/shared_stripe_examples/product_examples.rb
+++ b/spec/shared_stripe_examples/product_examples.rb
@@ -70,7 +70,7 @@ shared_examples "Product API" do
     stripe_helper.create_product(id: "prod_123", name: "First Product")
     stripe_helper.create_product(id: "prod_456", name: "Second Product")
 
-    all = Stripe::Product.all
+    all = Stripe::Product.list
     expect(all.count).to eq(2)
     expect(all.map &:id).to include("prod_123", "prod_456")
     expect(all.map &:name).to include("First Product", "Second Product")
@@ -80,7 +80,7 @@ shared_examples "Product API" do
     101.times do |i|
       stripe_helper.create_product(id: "Product #{i}", name: "My Product ##{i}")
     end
-    all = Stripe::Product.all(limit: 100)
+    all = Stripe::Product.list(limit: 100)
 
     expect(all.count).to eq(100)
   end

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -378,7 +378,7 @@ shared_examples 'Refund API' do
         description: 'card charge'
       )
 
-      charge = charge.refund(amount: 999)
+      charge = Stripe::Refund.create(charge: charge.id, amount: 999)
 
       expect(charge.refunded).to eq(true)
       expect(charge.refunds.data.first.amount).to eq(999)
@@ -392,7 +392,7 @@ shared_examples 'Refund API' do
         source: stripe_helper.generate_card_token,
         description: 'card charge'
       )
-      refund = charge.refund
+      refund = Stripe::Refund.create(charge: charge.id)
 
       expect(charge.id).to match(/^(test_)?ch/)
       expect(refund.id).to eq(charge.id)
@@ -405,7 +405,7 @@ shared_examples 'Refund API' do
         source: stripe_helper.generate_card_token,
         description: 'card charge'
       )
-      refund = charge.refund
+      refund = Stripe::Refund.create(charge: charge.id)
 
       expect(refund.refunds.data.count).to eq 1
       expect(refund.refunds.data.first.id).to match(/^test_re/)
@@ -418,7 +418,7 @@ shared_examples 'Refund API' do
         source: stripe_helper.generate_card_token,
         description: 'card charge'
       )
-      refund = charge.refund
+      refund = Stripe::Refund.create(charge: charge.id)
 
       expect(refund.refunds.data.count).to eq 1
       expect(refund.refunds.data.first.status).to eq("succeeded")
@@ -431,7 +431,7 @@ shared_examples 'Refund API' do
         source: stripe_helper.generate_card_token,
         description: 'card charge'
       )
-      refund = charge.refund
+      refund = Stripe::Refund.create(charge: charge.id)
 
       expect(charge.balance_transaction).not_to eq(refund.refunds.data.first.balance_transaction)
     end

--- a/spec/shared_stripe_examples/refund_examples.rb
+++ b/spec/shared_stripe_examples/refund_examples.rb
@@ -262,7 +262,7 @@ shared_examples 'Refund API' do
       end
 
       it "stores all charges in memory" do
-        expect(Stripe::Refund.all.data.map(&:id)).to eq([@refund2.id, @refund.id])
+        expect(Stripe::Refund.list.data.map(&:id)).to eq([@refund2.id, @refund.id])
       end
 
       it "defaults count to 10 charges" do
@@ -275,7 +275,7 @@ shared_examples 'Refund API' do
           Stripe::Refund.create(charge: charge.id)
         end
 
-        expect(Stripe::Refund.all.data.count).to eq(10)
+        expect(Stripe::Refund.list.data.count).to eq(10)
       end
 
       it "is marked as having more when more objects exist" do
@@ -288,12 +288,12 @@ shared_examples 'Refund API' do
           Stripe::Refund.create(charge: charge.id)
         end
 
-        expect(Stripe::Refund.all.has_more).to eq(true)
+        expect(Stripe::Refund.list.has_more).to eq(true)
       end
 
       context "when passing limit" do
         it "gets that many charges" do
-          expect(Stripe::Refund.all(limit: 1).count).to eq(1)
+          expect(Stripe::Refund.list(limit: 1).count).to eq(1)
         end
       end
     end
@@ -318,13 +318,13 @@ shared_examples 'Refund API' do
         Stripe::Refund.create(charge: charge.id)
       end
 
-      all = Stripe::Refund.all
+      all_refunds = Stripe::Refund.list
       default_limit = 10
-      half = Stripe::Refund.all(starting_after: all.data.at(1).id)
+      half = Stripe::Refund.list(starting_after: all_refunds.data.at(1).id)
 
       expect(half).to be_a(Stripe::ListObject)
       expect(half.data.count).to eq(default_limit)
-      expect(half.data.first.id).to eq(all.data.at(2).id)
+      expect(half.data.first.id).to eq(all_refunds.data.at(2).id)
     end
 
     describe "idempotency" do

--- a/spec/shared_stripe_examples/setup_intent_examples.rb
+++ b/spec/shared_stripe_examples/setup_intent_examples.rb
@@ -18,11 +18,11 @@ shared_examples 'SetupIntent API' do
     end
 
     it "without params retrieves all stripe setup_intent" do
-      expect(Stripe::SetupIntent.all.count).to eq(3)
+      expect(Stripe::SetupIntent.list.count).to eq(3)
     end
 
     it "accepts a limit param" do
-      expect(Stripe::SetupIntent.all(limit: 2).count).to eq(2)
+      expect(Stripe::SetupIntent.list(limit: 2).count).to eq(2)
     end
   end
 

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -33,25 +33,29 @@ shared_examples 'Customer Subscriptions' do
       expect(subscription.metadata.example).to eq("yes")
 
       customer = Stripe::Customer.retrieve(customer.id)
-      expect(customer.subscriptions.data).to_not be_empty
-      expect(customer.subscriptions.count).to eq(1)
-      expect(customer.subscriptions.data.length).to eq(1)
-      expect(customer.charges.data.length).to eq(1)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
+
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+      expect(charges.data.length).to eq(1)
       expect(customer.currency).to eq("usd")
 
-      expect(customer.subscriptions.data.first.id).to eq(subscription.id)
-      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
-      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-      expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
-      expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
+      expect(subscriptions.data.first.id).to eq(subscription.id)
+      expect(subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(subscriptions.data.first.metadata.foo).to eq( "bar" )
+      expect(subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
     it "adds a new subscription to customer with none", :live => true do
       plan
       customer = Stripe::Customer.create(source: gen_card_tk)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
 
-      expect(customer.subscriptions.data).to be_empty
-      expect(customer.subscriptions.count).to eq(0)
+      expect(subscriptions.data).to be_empty
+      expect(subscriptions.count).to eq(0)
 
       sub = Stripe::Subscription.create({ plan: 'silver', customer: customer.id, metadata: { foo: "bar", example: "yes" } })
 
@@ -61,26 +65,30 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.metadata.example).to eq( "yes" )
 
       customer = Stripe::Customer.retrieve(customer.id)
-      expect(customer.subscriptions.data).to_not be_empty
-      expect(customer.subscriptions.count).to eq(1)
-      expect(customer.subscriptions.data.length).to eq(1)
-      expect(customer.charges.data.length).to eq(1)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
+
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+      expect(charges.data.length).to eq(1)
       expect(customer.currency).to eq( "usd" )
 
-      expect(customer.subscriptions.data.first.id).to eq(sub.id)
-      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
-      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-      expect(customer.subscriptions.data.first.billing).to eq('charge_automatically')
-      expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
-      expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
+      expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(subscriptions.data.first.billing).to eq('charge_automatically')
+      expect(subscriptions.data.first.metadata.foo).to eq( "bar" )
+      expect(subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
     it 'when customer object provided' do
       plan
       customer = Stripe::Customer.create(source: gen_card_tk)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
 
-      expect(customer.subscriptions.data).to be_empty
-      expect(customer.subscriptions.count).to eq(0)
+      expect(subscriptions.data).to be_empty
+      expect(subscriptions.count).to eq(0)
 
       sub = Stripe::Subscription.create({ plan: 'silver', customer: customer, metadata: { foo: "bar", example: "yes" } })
 
@@ -91,39 +99,46 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.metadata.example).to eq( "yes" )
 
       customer = Stripe::Customer.retrieve(customer.id)
-      expect(customer.subscriptions.data).to_not be_empty
-      expect(customer.subscriptions.count).to eq(1)
-      expect(customer.subscriptions.data.length).to eq(1)
-      expect(customer.charges.data.length).to eq(1)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
+
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+      expect(charges.data.length).to eq(1)
       expect(customer.currency).to eq( "usd" )
 
-      expect(customer.subscriptions.data.first.id).to eq(sub.id)
-      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
+      expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.plan.to_hash).to eq(plan.to_hash)
 
-      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-      expect(customer.subscriptions.data.first.billing).to eq('charge_automatically')
-      expect(customer.subscriptions.data.first.metadata.foo).to eq( "bar" )
-      expect(customer.subscriptions.data.first.metadata.example).to eq( "yes" )
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(subscriptions.data.first.billing).to eq('charge_automatically')
+      expect(subscriptions.data.first.metadata.foo).to eq( "bar" )
+      expect(subscriptions.data.first.metadata.example).to eq( "yes" )
     end
 
     it "adds a new subscription to customer (string/symbol agnostic)" do
       customer = Stripe::Customer.create(source: gen_card_tk)
-      expect(customer.subscriptions.count).to eq(0)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      expect(subscriptions.count).to eq(0)
 
       plan
       sub = Stripe::Subscription.create({plan: plan.id, customer: customer.id })
+
       customer = Stripe::Customer.retrieve(customer.id)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
       expect(sub.plan.to_hash).to eq(plan.to_hash)
-      expect(customer.subscriptions.count).to eq(1)
+      expect(subscriptions.count).to eq(1)
     end
 
     it 'creates a charge for the customer', live: true do
       customer = Stripe::Customer.create(source: gen_card_tk)
       Stripe::Subscription.create({ plan: plan.id, customer: customer.id, metadata: { foo: "bar", example: "yes" } })
       customer = Stripe::Customer.retrieve(customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
 
-      expect(customer.charges.data.length).to eq(1)
-      expect(customer.charges.data.first.amount).to eq(4999)
+      expect(charges.data.length).to eq(1)
+      expect(charges.data.first.amount).to eq(4999)
     end
 
     it 'contains coupon object', live: true do
@@ -132,11 +147,13 @@ shared_examples 'Customer Subscriptions' do
       Stripe::Subscription.create(plan: plan.id, customer: customer.id, coupon: coupon.id)
       customer = Stripe::Customer.retrieve(customer.id)
 
-      expect(customer.subscriptions.data).to be_a(Array)
-      expect(customer.subscriptions.data.count).to eq(1)
-      expect(customer.subscriptions.data.first.discount).not_to be_nil
-      expect(customer.subscriptions.data.first.discount).to be_a(Stripe::Discount)
-      expect(customer.subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+
+      expect(subscriptions.data).to be_a(Array)
+      expect(subscriptions.data.count).to eq(1)
+      expect(subscriptions.data.first.discount).not_to be_nil
+      expect(subscriptions.data.first.discount).to be_a(Stripe::Discount)
+      expect(subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
     end
 
     it 'when coupon is not exist', live: true do
@@ -282,15 +299,18 @@ shared_examples 'Customer Subscriptions' do
       expect(sub.trial_end - sub.trial_start).to eq(14 * 86400)
       expect(sub.billing_cycle_anchor).to be_nil
 
-      customer = Stripe::Customer.retrieve('cardless')
-      expect(customer.subscriptions.data).to_not be_empty
-      expect(customer.subscriptions.count).to eq(1)
-      expect(customer.subscriptions.data.length).to eq(1)
+      customer = Stripe::Customer.retrieve(customer.id)
+      subscriptions = Stripe::Subscription.list(customer: customer.id)
+      charges = Stripe::Charge.list(customer: customer.id)
 
-      expect(customer.subscriptions.data.first.id).to eq(sub.id)
-      expect(customer.subscriptions.data.first.plan.to_hash).to eq(plan_with_trial.to_hash)
-      expect(customer.subscriptions.data.first.customer).to eq(customer.id)
-      expect(customer.charges.count).to eq(0)
+      expect(subscriptions.data).to_not be_empty
+      expect(subscriptions.count).to eq(1)
+      expect(subscriptions.data.length).to eq(1)
+
+      expect(subscriptions.data.first.id).to eq(sub.id)
+      expect(subscriptions.data.first.plan.to_hash).to eq(plan_with_trial.to_hash)
+      expect(subscriptions.data.first.customer).to eq(customer.id)
+      expect(charges.count).to eq(0)
     end
 
     it "subscribes a customer with no card to a plan with a free trial with plan as item" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1053,7 +1053,7 @@ shared_examples 'Customer Subscriptions' do
       customer = Stripe::Customer.create(id: 'test_customer_sub', source: gen_card_tk, plan: free_plan.id)
       Stripe::Subscription.create({ plan: 'paid', customer: customer.id })
 
-      subs = Stripe::Subscription.all({ customer: customer.id })
+      subs = Stripe::Subscription.list({ customer: customer.id })
 
       expect(subs.object).to eq("list")
       expect(subs.count).to eq(2)
@@ -1064,7 +1064,7 @@ shared_examples 'Customer Subscriptions' do
       Stripe::Customer.create(id: 'no_subs')
       customer = Stripe::Customer.retrieve('no_subs')
 
-      list = Stripe::Subscription.all({ customer: customer.id })
+      list = Stripe::Subscription.list({ customer: customer.id })
 
       expect(list.object).to eq("list")
       expect(list.count).to eq(0)

--- a/spec/shared_stripe_examples/transfer_examples.rb
+++ b/spec/shared_stripe_examples/transfer_examples.rb
@@ -40,22 +40,22 @@ shared_examples 'Transfer API' do
     end
 
     it "without params retrieves all tripe transfers" do
-      expect(Stripe::Transfer.all.count).to eq(3)
+      expect(Stripe::Transfer.list.count).to eq(3)
     end
 
     it "accepts a limit param" do
-      expect(Stripe::Transfer.all(limit: 2).count).to eq(2)
+      expect(Stripe::Transfer.list(limit: 2).count).to eq(2)
     end
 
     it "filters the search to a specific destination" do
       d2 = Stripe::Account.create(type: "custom", email: "#{SecureRandom.uuid}@example.com", business_name: "MyCo")
       Stripe::Transfer.create(amount: "100", currency: "usd", destination: d2.id)
 
-      expect(Stripe::Transfer.all(destination: d2.id).count).to eq(1)
+      expect(Stripe::Transfer.list(destination: d2.id).count).to eq(1)
     end
 
     it "disallows unknown parameters" do
-      expect { Stripe::Transfer.all(recipient: "foo") }.to raise_error {|e|
+      expect { Stripe::Transfer.list(recipient: "foo") }.to raise_error {|e|
         expect(e).to be_a Stripe::InvalidRequestError
         expect(e.param).to eq("recipient")
         expect(e.message).to eq("Received unknown parameter: recipient")

--- a/spec/shared_stripe_examples/webhook_event_examples.rb
+++ b/spec/shared_stripe_examples/webhook_event_examples.rb
@@ -168,7 +168,7 @@ shared_examples 'Webhook Events API' do
       expect(invoice_item_created_event).to be_a(Stripe::Event)
       expect(invoice_item_created_event).to_not be_nil
 
-      events = Stripe::Event.all
+      events = Stripe::Event.list
 
       expect(events.count).to eq(5)
       expect(events.map &:id).to include(customer_created_event.id, plan_created_event.id, coupon_created_event.id, invoice_created_event.id, invoice_item_created_event.id)
@@ -196,7 +196,7 @@ shared_examples 'Webhook Events API' do
       expect(invoice_item_created_event).to be_a(Stripe::Event)
       expect(invoice_item_created_event).to_not be_nil
 
-      events = Stripe::Event.all(limit: 3)
+      events = Stripe::Event.list(limit: 3)
 
       expect(events.count).to eq(3)
       expect(events.map &:id).to include(invoice_item_created_event.id, invoice_created_event.id, coupon_created_event.id)
@@ -204,9 +204,9 @@ shared_examples 'Webhook Events API' do
     end
 
   end
-  
-  describe 'Subscription events' do 
-    it "Checks for billing items in customer.subscription.created" do 
+
+  describe 'Subscription events' do
+    it "Checks for billing items in customer.subscription.created" do
       subscription_created_event = StripeMock.mock_webhook_event('customer.subscription.created')
       expect(subscription_created_event).to be_a(Stripe::Event)
       expect(subscription_created_event.id).to_not be_nil
@@ -216,7 +216,7 @@ shared_examples 'Webhook Events API' do
       expect(subscription_created_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
 
-    it "Checks for billing items in customer.subscription.deleted" do 
+    it "Checks for billing items in customer.subscription.deleted" do
       subscription_deleted_event = StripeMock.mock_webhook_event('customer.subscription.deleted')
       expect(subscription_deleted_event).to be_a(Stripe::Event)
       expect(subscription_deleted_event.id).to_not be_nil
@@ -225,8 +225,8 @@ shared_examples 'Webhook Events API' do
       expect(subscription_deleted_event.data.object.items.data.first).to respond_to(:plan)
       expect(subscription_deleted_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
-    
-    it "Checks for billing items in customer.subscription.updated" do 
+
+    it "Checks for billing items in customer.subscription.updated" do
       subscription_updated_event = StripeMock.mock_webhook_event('customer.subscription.updated')
       expect(subscription_updated_event).to be_a(Stripe::Event)
       expect(subscription_updated_event.id).to_not be_nil
@@ -235,8 +235,8 @@ shared_examples 'Webhook Events API' do
       expect(subscription_updated_event.data.object.items.data.first).to respond_to(:plan)
       expect(subscription_updated_event.data.object.items.data.first.id).to eq('si_00000000000000')
     end
-    
-    it "Checks for billing items in customer.subscription.trial_will_end" do 
+
+    it "Checks for billing items in customer.subscription.trial_will_end" do
       subscription_trial_will_end_event = StripeMock.mock_webhook_event('customer.subscription.trial_will_end')
       expect(subscription_trial_will_end_event).to be_a(Stripe::Event)
       expect(subscription_trial_will_end_event.id).to_not be_nil
@@ -247,7 +247,7 @@ shared_examples 'Webhook Events API' do
     end
   end
 
-  describe 'Invoices events' do 
+  describe 'Invoices events' do
     it "Checks for billing items in invoice.payment_succeeded" do
       invoice_payment_succeeded = StripeMock.mock_webhook_event('invoice.payment_succeeded')
       expect(invoice_payment_succeeded).to be_a(Stripe::Event)

--- a/spec/stripe_mock_spec.rb
+++ b/spec/stripe_mock_spec.rb
@@ -18,14 +18,14 @@ describe StripeMock do
     StripeMock.start
     Stripe::StripeClient.active_client.execute_request(:xtest, '/', api_key: 'abcde') # no error
     StripeMock.stop
-    expect { Stripe::StripeClient.active_client.execute_request(:x, '/', api_key: 'abcde') }.to raise_error ArgumentError
+    expect { Stripe::StripeClient.active_client.execute_request(:x, '/', api_key: 'abcde') }.to raise_error Stripe::APIError
   end
 
   it "reverts overriding stripe's execute_request method in other threads" do
     StripeMock.start
     Thread.new { Stripe::StripeClient.active_client.execute_request(:xtest, '/', api_key: 'abcde') }.join # no error
     StripeMock.stop
-    expect { Thread.new { Stripe::StripeClient.active_client.execute_request(:x, '/', api_key: 'abcde') }.join }.to raise_error ArgumentError
+    expect { Thread.new { Stripe::StripeClient.active_client.execute_request(:x, '/', api_key: 'abcde') }.join }.to raise_error Stripe::APIError
   end
 
   it "does not persist data between mock sessions" do

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 2.0.3', '< 5'
+  gem.add_dependency 'stripe', '> 5', '< 6'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Hey there,

this PR is a work in progress to start making the Gem compatible with version 5 of the Stripe gem. Contrary to the implementation started in #643, I am explicitly dropping compatability with all lower gems. As discussed in #646 it is planned to release a version 3 of this gem anyways that will require Stripe 5.

I hope nobody else started working on this, I looked through the branches here, but did not check all 500 forks.

## TODOs

- [x] Update the `StripeError` implementation to use `code` as a keyword argument
  - [x] Drive-By-Refactoring: Correctly generate `http_body` as this should contain the unparsed JSON body
  - [ ] Think about refactoring those errors to correctly include the object that caused the error
- [x] Rename all instances of `all` to `list` (https://github.com/stripe/stripe-ruby/pull/823)
- [x] Change instance methods that were removed in favor of better named class methods (https://github.com/stripe/stripe-ruby/pull/820) i.e. `customer.invoice_items -> InvoiceItems.list(customer: customer.id)`

Migration Guide: https://github.com/stripe/stripe-ruby/wiki/Migration-guide-for-v5#removed-methods