### PR TITLE
Prevent customer metadata from being overwritten with each update

### DIFF
--- a/lib/stripe_mock/request_handlers/customers.rb
+++ b/lib/stripe_mock/request_handlers/customers.rb
@@ -60,6 +60,7 @@ module StripeMock
       def update_customer(route, method_url, params, headers)
         route =~ method_url
         cus = assert_existence :customer, $1, customers[$1]
+        metadata = params.delete(:metadata) if params[:metadata]
 
         # Delete those params if their value is nil. Workaround of the problematic way Stripe serialize objects
         params.delete(:sources) if params[:sources] && params[:sources][:data].nil?
@@ -72,6 +73,7 @@ module StripeMock
           params.delete(:subscriptions) unless params[:subscriptions][:data].any?{ |v| !!v[:type]}
         end
         cus.merge!(params)
+        cus[:metadata].merge!(metadata)
 
         if params[:source]
           if params[:source].is_a?(String)

--- a/spec/shared_stripe_examples/customer_examples.rb
+++ b/spec/shared_stripe_examples/customer_examples.rb
@@ -353,6 +353,15 @@ shared_examples 'Customer API' do
     expect(customer.discount.coupon).to be_a Stripe::Coupon
   end
 
+  it "preserves stripe customer metadata", focus: true do
+    metadata = {user_id: "38"}
+    customer = Stripe::Customer.create(metadata: metadata)
+    expect(customer.metadata.to_h).to eq(metadata)
+
+    updated = Stripe::Customer.update(customer.id, metadata: {fruit: "apples"})
+    expect(updated.metadata.to_h).to eq(metadata.merge(fruit: "apples"))
+  end
+
   it "retrieves the customer's default source after it was updated" do
     customer = Stripe::Customer.create()
     customer.source = gen_card_tk

--- a/stripe-ruby-mock.gemspec
+++ b/stripe-ruby-mock.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'stripe', '>= 2.0.3', '< 5'
+  gem.add_dependency 'stripe', '>= 2.0.3'
   gem.add_dependency 'multi_json', '~> 1.0'
   gem.add_dependency 'dante', '>= 0.2.0'
 


### PR DESCRIPTION
Currently if you create a customer with metadata then update that customer's metadata, it's completely blown away in favor of the new hash. This is not how stripe's customer update endpoint treats metadata. It's always merged in which preserves existing metadata. This PR achieves that same functionality.